### PR TITLE
Remove duplicate slash

### DIFF
--- a/App/Setup/Assets.php
+++ b/App/Setup/Assets.php
@@ -104,14 +104,14 @@ class Assets {
 	public function _wp_enqueue_scripts() {
 		wp_enqueue_style(
 			'snow-monkey-blocks',
-			SNOW_MONKEY_BLOCKS_DIR_URL . '/dist/css/blocks.min.css',
+			SNOW_MONKEY_BLOCKS_DIR_URL . 'dist/css/blocks.min.css',
 			[],
 			filemtime( SNOW_MONKEY_BLOCKS_DIR_PATH . '/dist/css/blocks.min.css' )
 		);
 
 		wp_register_script(
 			'masonry-layout',
-			SNOW_MONKEY_BLOCKS_DIR_URL . '/dist/packages/masonry-layout/dist/masonry.pkgd.min.js',
+			SNOW_MONKEY_BLOCKS_DIR_URL . 'dist/packages/masonry-layout/dist/masonry.pkgd.min.js',
 			[],
 			filemtime( SNOW_MONKEY_BLOCKS_DIR_PATH . '/dist/packages/masonry-layout/dist/masonry.pkgd.min.js' ),
 			true
@@ -119,7 +119,7 @@ class Assets {
 
 		wp_enqueue_script(
 			'snow-monkey-blocks',
-			SNOW_MONKEY_BLOCKS_DIR_URL . '/dist/js/app.min.js',
+			SNOW_MONKEY_BLOCKS_DIR_URL . 'dist/js/app.min.js',
 			[ 'jquery', 'masonry-layout' ],
 			filemtime( SNOW_MONKEY_BLOCKS_DIR_PATH . '/dist/js/app.min.js' ),
 			true


### PR DESCRIPTION
![2019-01-07 10 38 57](https://user-images.githubusercontent.com/6883571/50744720-ffdbbb80-1268-11e9-93df-f1046478dda9.png)


## Expected

```
<script type="text/javascript" src="https://example.com/wp-content/plugins/snow-monkey-blocks/dist/js/app.min.js?ver=1546484127"></script>
```

## Actual

```
<script type="text/javascript" src="https://example.com/wp-content/plugins/snow-monkey-blocks//dist/js/app.min.js?ver=1546484127"></script>
```

## Description
I think the `/` is not necessary.
Because the slash before the dist is duplicated, then the plugin does not work in Shifter.