### PR TITLE
編集時に高度な設定のclass設定を反映するように修正

### DIFF
--- a/block/accordion/block.js
+++ b/block/accordion/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { registerBlockType } = wp.blocks;
 const { InnerBlocks } = wp.editor;
 const { __ } = wp.i18n;
@@ -9,12 +11,12 @@ registerBlockType( 'snow-monkey-blocks/accordion', {
 	icon: 'editor-justify',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/accordion--item' ];
 		const template = [ [ 'snow-monkey-blocks/accordion--item' ] ];
 
 		return (
-			<div className="smb-accordion">
+			<div className={ classnames( 'smb-accordion', className ) }>
 				<InnerBlocks
 					allowedBlocks={ allowedBlocks }
 					template={ template }

--- a/block/accordion/item/block.js
+++ b/block/accordion/item/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { registerBlockType } = wp.blocks;
 const { RichText, InnerBlocks } = wp.editor;
 const { __ } = wp.i18n;
@@ -16,11 +18,11 @@ registerBlockType( 'snow-monkey-blocks/accordion--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { title } = attributes;
 
 		return (
-			<div className="smb-accordion__item">
+			<div className={ classnames( 'smb-accordion__item', className ) }>
 				<div className="smb-accordion__item__title">
 					<RichText
 						value={ title }

--- a/block/alert/block.js
+++ b/block/alert/block.js
@@ -35,7 +35,7 @@ registerBlockType( 'snow-monkey-blocks/alert', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, content, modifier, icon } = attributes;
 
 		const iconList = [
@@ -125,7 +125,7 @@ registerBlockType( 'snow-monkey-blocks/alert', {
 						</BaseControl>
 					</PanelBody>
 				</InspectorControls>
-				<div className={ classnames( 'smb-alert', { [ `smb-alert--${ modifier }` ]: !! modifier } ) }>
+				<div className={ classnames( 'smb-alert', { [ `smb-alert--${ modifier }` ]: !! modifier }, className ) }>
 					{ ( ! RichText.isEmpty( title ) || isSelected ) &&
 						<div className="smb-alert__title">
 							{ renderFontAwesomeIcon() }

--- a/block/balloon/block.js
+++ b/block/balloon/block.js
@@ -42,7 +42,7 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { avatarID, avatarURL, avatarBorderColor, balloonName, balloonBody, modifier } = attributes;
 
 		const renderAvatar = ( obj ) => {
@@ -88,7 +88,7 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className={ classnames( 'smb-balloon', { [ `smb-balloon--${ modifier }` ]: !! modifier } ) }>
+				<div className={ classnames( 'smb-balloon', { [ `smb-balloon--${ modifier }` ]: !! modifier }, className ) }>
 					<div className="smb-balloon__person">
 						<div
 							className="smb-balloon__figure"

--- a/block/box/block.js
+++ b/block/box/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 
 const { registerBlockType } = wp.blocks;
@@ -28,7 +29,7 @@ registerBlockType( 'snow-monkey-blocks/box', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { backgroundColor, borderColor, textColor, borderWidth } = attributes;
 
 		return (
@@ -73,7 +74,7 @@ registerBlockType( 'snow-monkey-blocks/box', {
 				</InspectorControls>
 
 				<div
-					className="smb-box"
+					className={ classnames( 'smb-box', className ) }
 					style={ { backgroundColor: backgroundColor, borderColor: borderColor, color: textColor, borderWidth: borderWidth } }
 				>
 					<div className="smb-box__body">

--- a/block/btn-box/block.js
+++ b/block/btn-box/block.js
@@ -53,7 +53,7 @@ registerBlockType( 'snow-monkey-blocks/btn-box', {
 		align: [ 'wide', 'full' ],
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { lede, note, backgroundColor, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, btnSize } = attributes;
 
 		return (
@@ -129,7 +129,7 @@ registerBlockType( 'snow-monkey-blocks/btn-box', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="smb-btn-box" style={ { backgroundColor: backgroundColor } }>
+				<div className={ classnames( 'smb-btn-box', className ) } style={ { backgroundColor: backgroundColor } }>
 					<div className="c-container">
 						{ ( ! RichText.isEmpty( lede ) || isSelected ) &&
 							<RichText

--- a/block/btn/block.js
+++ b/block/btn/block.js
@@ -41,7 +41,7 @@ registerBlockType( 'snow-monkey-blocks/btn', {
 		align: [ 'left', 'center', 'right' ],
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { content, url, target, modifier, backgroundColor, textColor } = attributes;
 
 		return (
@@ -110,7 +110,7 @@ registerBlockType( 'snow-monkey-blocks/btn', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="u-clearfix smb-btn-wrapper">
+				<div className={ classnames( 'u-clearfix', 'smb-btn-wrapper', className ) }>
 					<span
 						className={ classnames( 'smb-btn', { [ `smb-btn--${ modifier }` ]: !! modifier } ) } href={ url } target={ target }
 						style={ { backgroundColor: backgroundColor } }

--- a/block/evaluation-star/block.js
+++ b/block/evaluation-star/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -37,7 +38,7 @@ registerBlockType( 'snow-monkey-blocks/evaluation-star', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { evaluationValue, iconColor, isDisplayNumeric, numericAlign, numericColor } = attributes;
 
 		const renderEditEvaluationIcon = () => {
@@ -150,7 +151,7 @@ registerBlockType( 'snow-monkey-blocks/evaluation-star', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="smb-evaluation-star">
+				<div className={ classnames( 'smb-evaluation-star', className ) }>
 					<div className="smb-evaluation-star__body">
 						<span
 							className={ `smb-evaluation-star__numeric smb-evaluation-star__numeric--${ numericAlign }` }

--- a/block/faq/block.js
+++ b/block/faq/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
@@ -11,12 +12,12 @@ registerBlockType( 'snow-monkey-blocks/faq', {
 	icon: 'businessman',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/faq--item' ];
 		const template = [ [ 'snow-monkey-blocks/faq--item' ] ];
 
 		return (
-			<div className="smb-faq">
+			<div className={ classnames( 'smb-faq', className ) }>
 				<div className="smb-faq__body">
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }

--- a/block/faq/item/block.js
+++ b/block/faq/item/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { registerBlockType } = wp.blocks;
 const { RichText, InspectorControls, PanelColorSettings } = wp.editor;
 const { Fragment } = wp.element;
@@ -27,7 +29,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { question, answer, questionColor, answerColor } = attributes;
 
 		return (
@@ -51,7 +53,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="smb-faq__item">
+				<div className={ classnames( 'smb-faq__item', className ) }>
 					<div className="smb-faq__item__question">
 						<div className="smb-faq__item__question__label" style={ { color: questionColor } }>
 							Q

--- a/block/items/block.js
+++ b/block/items/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 import { deprecated } from './_deprecated.js';
 
@@ -28,7 +29,7 @@ registerBlockType( 'snow-monkey-blocks/items', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { sm, md, lg } = attributes;
 
 		const allowedBlocks = [ 'snow-monkey-blocks/items--item' ];
@@ -99,7 +100,7 @@ registerBlockType( 'snow-monkey-blocks/items', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-items">
+				<div className={ classnames( 'smb-items', className ) }>
 					<div className="c-row c-row--margin" data-columns={ sm } data-md-columns={ md } data-lg-columns={ lg }>
 						<InnerBlocks
 							allowedBlocks={ allowedBlocks }

--- a/block/items/item/block.js
+++ b/block/items/item/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { times } = lodash;
 const { registerBlockType } = wp.blocks;
 const { InspectorControls, RichText, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker } = wp.editor;
@@ -70,7 +72,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { titleTagName, title, lede, summary, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, isBlockLink } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
@@ -195,7 +197,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 				</InspectorControls>
 
 				<div className="c-row__col">
-					<div className="smb-items__item">
+					<div className={ classnames( 'smb-items__item', className ) }>
 						{ ( !! imageID || isSelected ) &&
 							<div className="smb-items__item__figure">
 								{ renderMedia() }

--- a/block/list/block.js
+++ b/block/list/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { times } = lodash;
 const { registerBlockType } = wp.blocks;
 const { RichText, InspectorControls, PanelColorSettings } = wp.editor;
@@ -26,7 +28,7 @@ registerBlockType( 'snow-monkey-blocks/list', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { content, icon, iconColor } = attributes;
 
 		const iconList = [
@@ -105,7 +107,7 @@ registerBlockType( 'snow-monkey-blocks/list', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="smb-list" data-icon={ icon } data-icon-color={ iconColor }>
+				<div className={ classnames( 'smb-list', className ) } data-icon={ icon } data-icon-color={ iconColor }>
 					<RichText
 						tagName="ul"
 						multiline="li"

--- a/block/media-text/block.js
+++ b/block/media-text/block.js
@@ -62,7 +62,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, imageID, imageURL, imagePosition, imageColumnSize } = attributes;
 
 		const { textColumnWidth, imageColumnWidth } = _getColumnsSize( imageColumnSize );
@@ -157,7 +157,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-media-text">
+				<div className={ classnames( 'smb-media-text', className ) }>
 					<div className={ classnames( 'c-row', 'c-row--margin', 'c-row--middle', { 'c-row--reverse': 'left' === imagePosition } ) }>
 						<div className={ `c-row__col c-row__col--1-1 c-row__col--lg-${ textColumnWidth }` }>
 							{ ( ! RichText.isEmpty( title ) || isSelected ) &&

--- a/block/panels/block.js
+++ b/block/panels/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 import { deprecated } from './_deprecated.js';
 
@@ -36,7 +37,7 @@ registerBlockType( 'snow-monkey-blocks/panels', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { sm, md, lg, imagePadding } = attributes;
 
 		const allowedBlocks = [ 'snow-monkey-blocks/panels--item' ];
@@ -113,7 +114,7 @@ registerBlockType( 'snow-monkey-blocks/panels', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-panels" data-image-padding={ imagePadding }>
+				<div className={ classnames( 'smb-panels', className ) } data-image-padding={ imagePadding }>
 					<div className="c-row c-row--margin c-row--fill" data-columns={ sm } data-md-columns={ md } data-lg-columns={ lg }>
 						<InnerBlocks
 							allowedBlocks={ allowedBlocks }

--- a/block/panels/item/horizontal/block.js
+++ b/block/panels/item/horizontal/block.js
@@ -62,7 +62,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imagePosition, imageID, imageURL } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
@@ -175,7 +175,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 
 				<div className="c-row__col">
 					<div
-						className={ classnames( 'smb-panels__item', 'smb-panels__item--horizontal', { 'smb-panels__item--reverse': 'right' === imagePosition } ) }
+						className={ classnames( 'smb-panels__item', 'smb-panels__item--horizontal', { 'smb-panels__item--reverse': 'right' === imagePosition }, className ) }
 						href={ linkURL }
 						target={ linkTarget }
 					>

--- a/block/panels/item/vertical/block.js
+++ b/block/panels/item/vertical/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { times } = lodash;
 const { registerBlockType } = wp.blocks;
 const { InspectorControls, RichText, MediaPlaceholder, MediaUpload } = wp.editor;
@@ -56,7 +58,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imageID, imageURL } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
@@ -153,7 +155,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 
 				<div className="c-row__col">
 					<div
-						className="smb-panels__item"
+						className={ classnames( 'smb-panels__item', className ) }
 						href={ linkURL }
 						target={ linkTarget }
 					>

--- a/block/pricing-table/block.js
+++ b/block/pricing-table/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
@@ -11,12 +12,12 @@ registerBlockType( 'snow-monkey-blocks/pricing-table', {
 	icon: 'warning',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/pricing-table--item' ];
 		const template = [ [ 'snow-monkey-blocks/pricing-table--item' ] ];
 
 		return (
-			<div className="smb-pricing-table">
+			<div className={ classnames( 'smb-pricing-table', className ) }>
 				<div className="c-row c-row--md-nowrap" data-columns>
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }

--- a/block/pricing-table/item/block.js
+++ b/block/pricing-table/item/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { registerBlockType } = wp.blocks;
 const { RichText, InspectorControls, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker } = wp.editor;
 const { PanelBody, SelectControl, TextControl, Button } = wp.components;
@@ -65,7 +67,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, price, lede, list, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
 
 		const onSelectImage = ( media ) => {
@@ -162,7 +164,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="c-row__col">
+				<div className={ classnames( 'c-row__col', className ) }>
 					<div className="smb-pricing-table__item">
 						{ ( !! imageID || isSelected ) &&
 							<div className="smb-pricing-table__item__figure">

--- a/block/rating-box/block.js
+++ b/block/rating-box/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
@@ -11,12 +12,12 @@ registerBlockType( 'snow-monkey-blocks/rating-box', {
 	icon: 'editor-alignleft',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/rating-box--item' ];
 		const template = [ [ 'snow-monkey-blocks/rating-box--item' ] ];
 
 		return (
-			<div className="smb-rating-box">
+			<div className={ classnames( 'smb-rating-box', className ) }>
 				<div className="smb-rating-box__body">
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }

--- a/block/rating-box/item/block.js
+++ b/block/rating-box/item/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../../src/js/helper/to-number';
 
 const { registerBlockType } = wp.blocks;
@@ -27,7 +28,7 @@ registerBlockType( 'snow-monkey-blocks/rating-box--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes } ) {
+	edit( { attributes, setAttributes, className } ) {
 		const { title, rating, color } = attributes;
 
 		return (
@@ -57,7 +58,7 @@ registerBlockType( 'snow-monkey-blocks/rating-box--item', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className="smb-rating-box__item">
+				<div className={ classnames( 'smb-rating-box__item', className ) }>
 					<RichText
 						className="smb-rating-box__item__title"
 						placeholder={ __( 'Write title...', 'snow-monkey-blocks' ) }

--- a/block/section-with-bgimage/block.js
+++ b/block/section-with-bgimage/block.js
@@ -20,7 +20,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 		align: [ 'wide', 'full' ],
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, imageID, imageURL, height, contentsAlignment, maskColor, maskOpacity, textColor, parallax } = attributes;
 
 		return (
@@ -110,7 +110,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 						allowedTypes={ [ 'image' ] }
 					/>
 				}
-				<div className={ classnames( `smb-section smb-section-with-bgimage smb-section-with-bgimage--${ contentsAlignment } smb-section-with-bgimage--${ height }`, { 'js-bg-parallax': !! parallax } ) } style={ { color: textColor } }>
+				<div className={ classnames( `smb-section smb-section-with-bgimage smb-section-with-bgimage--${ contentsAlignment } smb-section-with-bgimage--${ height }`, { 'js-bg-parallax': !! parallax }, className ) } style={ { color: textColor } }>
 					{ !! imageURL && isSelected &&
 						<button
 							className="smb-remove-button"

--- a/block/section/block.js
+++ b/block/section/block.js
@@ -22,7 +22,7 @@ registerBlockType( 'snow-monkey-blocks/section', {
 		anchor: true,
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, backgroundColor, contentsWidth, topDividerType, topDividerLevel, topDividerColor, bottomDividerType, bottomDividerLevel, bottomDividerColor } = attributes;
 
 		return (
@@ -144,7 +144,7 @@ registerBlockType( 'snow-monkey-blocks/section', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-section" style={ { backgroundColor: backgroundColor } }>
+				<div className={ classnames( 'smb-section', className ) } style={ { backgroundColor: backgroundColor } }>
 					{ !! topDividerLevel &&
 						<div className={ `smb-section__divider smb-section__divider--top smb-section__divider--${ topDividerType }` }>
 							{ divider( topDividerType, topDividerLevel, topDividerColor ) }

--- a/block/slider/block.js
+++ b/block/slider/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 import generateUpdatedAttribute from '../../src/js/helper/generate-updated-attribute';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -97,7 +98,7 @@ registerBlockType( 'snow-monkey-blocks/slider', {
 		align: [ 'wide', 'full' ],
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { slidesToShow, slidesToScroll, dots, arrows, items, content, speed, autoplaySpeed, rtl } = attributes;
 
 		return (
@@ -165,7 +166,7 @@ registerBlockType( 'snow-monkey-blocks/slider', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-slider">
+				<div className={ classnames( 'smb-slider', className ) }>
 					<div className="smb-slider__canvas">
 						{ times( items, ( index ) => {
 							if ( ! isSelected && 0 < index ) {

--- a/block/step/block.js
+++ b/block/step/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
@@ -11,12 +12,12 @@ registerBlockType( 'snow-monkey-blocks/step', {
 	icon: 'editor-ol',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/step--item' ];
 		const template = [ [ 'snow-monkey-blocks/step--item' ] ];
 
 		return (
-			<div className="smb-step">
+			<div className={ classnames( 'smb-step', className ) }>
 				<div className="smb-step__body">
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }

--- a/block/step/item/block.js
+++ b/block/step/item/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 import { schema } from './_schema.js';
 
@@ -16,7 +17,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 	parent: [ 'snow-monkey-blocks/step' ],
 	attributes: schema,
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { title, numberColor, imagePosition, imageID, imageURL, linkLabel, linkURL, linkTarget, linkColor } = attributes;
 
 		const onSelectImage = ( media ) => {
@@ -131,7 +132,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 					</PanelColorSettings>
 				</InspectorControls>
 
-				<div className={ `smb-step__item smb-step__item--image-${ imagePosition }` }>
+				<div className={ classnames( `smb-step__item smb-step__item--image-${ imagePosition }`, className ) }>
 					<div className="smb-step__item__title">
 						<div className="smb-step__item__number" style={ { backgroundColor: numberColor } }></div>
 						<span>

--- a/block/testimonial/block.js
+++ b/block/testimonial/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
@@ -11,12 +12,12 @@ registerBlockType( 'snow-monkey-blocks/testimonial', {
 	icon: 'admin-comments',
 	category: 'smb',
 
-	edit() {
+	edit( { className } ) {
 		const allowedBlocks = [ 'snow-monkey-blocks/testimonial--item' ];
 		const template = [ [ 'snow-monkey-blocks/testimonial--item' ] ];
 
 		return (
-			<div className="smb-testimonial">
+			<div className={ classnames( 'smb-testimonial', className ) }>
 				<div className="smb-testimonial__body">
 					<div className="c-row c-row--margin" data-columns="1" data-md-columns="2">
 						<InnerBlocks

--- a/block/testimonial/item/block.js
+++ b/block/testimonial/item/block.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import classnames from 'classnames';
+
 const { registerBlockType } = wp.blocks;
 const { RichText, MediaUpload } = wp.editor;
 const { Button } = wp.components;
@@ -36,7 +38,7 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 		},
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { avatarID, avatarURL, name, lede, content } = attributes;
 
 		const renderAvatar = ( obj ) => {
@@ -48,7 +50,7 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 		};
 
 		return (
-			<div className="c-row__col">
+			<div className={ classnames( 'c-row__col', className ) }>
 				<div className="smb-testimonial__item">
 					{ ( !! avatarID || isSelected ) &&
 						<div className="smb-testimonial__item__figure">

--- a/block/thumbnail-gallery/block.js
+++ b/block/thumbnail-gallery/block.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import classnames from 'classnames';
 import toNumber from '../../src/js/helper/to-number';
 import generateUpdatedAttribute from '../../src/js/helper/generate-updated-attribute';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -47,7 +48,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery', {
 		align: [ 'wide', 'full' ],
 	},
 
-	edit( { attributes, setAttributes, isSelected } ) {
+	edit( { attributes, setAttributes, isSelected, className } ) {
 		const { items, content } = attributes;
 
 		return (
@@ -64,7 +65,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery', {
 					</PanelBody>
 				</InspectorControls>
 
-				<div className="smb-thumbnail-gallery">
+				<div className={ classnames( 'smb-thumbnail-gallery', className ) }>
 					<div className="smb-thumbnail-gallery__canvas">
 						{ times( items, ( index ) => {
 							if ( ! isSelected && 0 < index ) {


### PR DESCRIPTION
編集時に高度な設定のCSSで設定されたclassを反映するように一通りの修正をしました。
※ サーバサイドブロックや編集時に反映されないブロックは除きます。

一応、上記以外のブロックではclass名が反映される確認を取っています。

＜確認事項・要調査事項＞
Snow Monkeyテーマで、CSSの読み込み順が実際の画面と編集時に異なるのか、
alertの場合はbackground-colorを適用しても編集画面には反映されなかったりするようです。
CSS読み込み順とか保存時と同じように出来たらと思ってます。
公式テーマだと上手くCSS順序が正しく出ているので、テーマの問題の可能性もありそうです。

・セクションの背景ありのブロックの方だけアンカーサポートがありませんが、これはどうすれば良いのか解らなかったのでそのままです。

最近の投稿ブロックで、高度な設定からClassを設定すると、「ブロック読み込みエラー: 無効なパラメーター: attributes」となる問題は、今回の修正で発生したものではありません。
こちら、いつからなのか解ってません。原因は調査中ですので、判明次第、別のプルリクで解決しようと思います。