### PR TITLE
最近の投稿ブロックで追加 CSS クラスを入力するとエラーとなる問題対応

### DIFF
--- a/block/recent-posts/block.php
+++ b/block/recent-posts/block.php
@@ -27,6 +27,10 @@ add_action(
 						'type' => 'string',
 						'default' => 'rich-media',
 					],
+					'className' => [
+						'type' => 'string',
+						'default' => '',
+					]
 				],
 				'render_callback' => function( $attributes ) {
 					return DynamicBlocks::render( 'recent-posts', $attributes );

--- a/block/recent-posts/view.php
+++ b/block/recent-posts/view.php
@@ -41,7 +41,7 @@ if ( empty( $widget ) ) {
 	return;
 }
 ?>
-<div class="smb-recent-posts">
+<div class="smb-recent-posts<?php echo !empty($attributes['className']) ? ' ' . $attributes['className'] : ''; ?>">
 	<?php
 	// @codingStandardsIgnoreStart
 	echo apply_filters( 'inc2734_wp_awesome_widgets_render_widget', $widget, $args, $instance );


### PR DESCRIPTION
「最近の投稿」ブロックで、「高度な設定」から「追加 CSS クラス」を入力するとエラーとなる問題を対応しました。
また、追加CSSクラスで追加したクラスを適用されるように修正しておきました。