### PR TITLE
URL入力を、TextControlからURLInputへ変更

### DIFF
--- a/block/btn-box/block.js
+++ b/block/btn-box/block.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
-const { RichText, InspectorControls, PanelColorSettings, ContrastChecker } = wp.editor;
-const { PanelBody, TextControl, SelectControl } = wp.components;
+const { RichText, InspectorControls, PanelColorSettings, ContrastChecker, URLInput } = wp.editor;
+const { PanelBody, BaseControl, SelectControl } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -62,11 +62,12 @@ registerBlockType( 'snow-monkey-blocks/btn-box', {
 					<PanelBody
 						title={ __( 'Button Settings', 'snow-monkey-blocks' ) }
 					>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ btnURL }
-							onChange={ ( value ) => setAttributes( { btnURL: value } ) }
-						/>
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ btnURL }
+								onChange={ ( value ) => setAttributes( { btnURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }

--- a/block/btn/block.js
+++ b/block/btn/block.js
@@ -3,8 +3,8 @@
 import classnames from 'classnames';
 
 const { registerBlockType } = wp.blocks;
-const { RichText, InspectorControls, PanelColorSettings, ContrastChecker } = wp.editor;
-const { PanelBody, SelectControl, TextControl } = wp.components;
+const { RichText, InspectorControls, PanelColorSettings, ContrastChecker, URLInput } = wp.editor;
+const { PanelBody, BaseControl, SelectControl } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -48,12 +48,12 @@ registerBlockType( 'snow-monkey-blocks/btn', {
 			<Fragment>
 				<InspectorControls>
 					<PanelBody title={ __( 'Button Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ url }
-							onChange={ ( value ) => setAttributes( { url: value } ) }
-						/>
-
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ url }
+								onChange={ ( value ) => setAttributes( { url: value } ) }
+							/>
+						</BaseControl>
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }
 							value={ target }

--- a/block/items/item/block.js
+++ b/block/items/item/block.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 
 const { times } = lodash;
 const { registerBlockType } = wp.blocks;
-const { InspectorControls, RichText, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker } = wp.editor;
-const { PanelBody, SelectControl, TextControl, BaseControl, Button, ToggleControl } = wp.components;
+const { InspectorControls, RichText, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker, URLInput } = wp.editor;
+const { PanelBody, SelectControl, BaseControl, Button, ToggleControl } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -150,11 +150,12 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 					</PanelBody>
 
 					<PanelBody title={ __( 'Button Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ btnURL }
-							onChange={ ( value ) => setAttributes( { btnURL: value } ) }
-						/>
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ btnURL }
+								onChange={ ( value ) => setAttributes( { btnURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }

--- a/block/panels/item/horizontal/block.js
+++ b/block/panels/item/horizontal/block.js
@@ -5,8 +5,8 @@ import { schema } from './_schema.js';
 
 const { times } = lodash;
 const { registerBlockType, createBlock } = wp.blocks;
-const { InspectorControls, RichText, MediaPlaceholder, MediaUpload } = wp.editor;
-const { PanelBody, SelectControl, TextControl, BaseControl, Button } = wp.components;
+const { InspectorControls, RichText, MediaPlaceholder, MediaUpload, URLInput } = wp.editor;
+const { PanelBody, SelectControl, BaseControl, Button } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -104,11 +104,12 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 					</PanelBody>
 
 					<PanelBody title={ __( 'Link Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ linkURL }
-							onChange={ ( value ) => setAttributes( { linkURL: value } ) }
-						/>
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ linkURL }
+								onChange={ ( value ) => setAttributes( { linkURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }

--- a/block/panels/item/vertical/block.js
+++ b/block/panels/item/vertical/block.js
@@ -5,8 +5,8 @@ import { schema } from './_schema.js';
 
 const { times } = lodash;
 const { registerBlockType, createBlock } = wp.blocks;
-const { InspectorControls, RichText, MediaPlaceholder, MediaUpload } = wp.editor;
-const { PanelBody, SelectControl, TextControl, BaseControl, Button } = wp.components;
+const { InspectorControls, RichText, MediaPlaceholder, MediaUpload, URLInput } = wp.editor;
+const { PanelBody, SelectControl, BaseControl, Button } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -88,11 +88,12 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 					</PanelBody>
 
 					<PanelBody title={ __( 'Link Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ linkURL }
-							onChange={ ( value ) => setAttributes( { linkURL: value } ) }
-						/>
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ linkURL }
+								onChange={ ( value ) => setAttributes( { linkURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }

--- a/block/pricing-table/item/block.js
+++ b/block/pricing-table/item/block.js
@@ -3,8 +3,8 @@
 import classnames from 'classnames';
 
 const { registerBlockType } = wp.blocks;
-const { RichText, InspectorControls, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker } = wp.editor;
-const { PanelBody, SelectControl, TextControl, Button } = wp.components;
+const { RichText, InspectorControls, MediaPlaceholder, MediaUpload, PanelColorSettings, ContrastChecker, URLInput } = wp.editor;
+const { PanelBody, BaseControl, SelectControl, Button } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -118,11 +118,12 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 			<Fragment>
 				<InspectorControls>
 					<PanelBody title={ __( 'Button Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'URL', 'snow-monkey-blocks' ) }
-							value={ btnURL }
-							onChange={ ( value ) => setAttributes( { btnURL: value } ) }
-						/>
+						<BaseControl label={ __( 'URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ btnURL }
+								onChange={ ( value ) => setAttributes( { btnURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Target', 'snow-monkey-blocks' ) }

--- a/block/step/item/block.js
+++ b/block/step/item/block.js
@@ -5,8 +5,8 @@ import { deprecated } from './_deprecated.js';
 import { schema } from './_schema.js';
 
 const { registerBlockType } = wp.blocks;
-const { RichText, InspectorControls, PanelColorSettings, MediaPlaceholder, MediaUpload, InnerBlocks } = wp.editor;
-const { PanelBody, SelectControl, TextControl, Button } = wp.components;
+const { RichText, InspectorControls, PanelColorSettings, MediaPlaceholder, MediaUpload, InnerBlocks, URLInput } = wp.editor;
+const { PanelBody, BaseControl, SelectControl, Button } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
@@ -90,11 +90,12 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 					</PanelBody>
 
 					<PanelBody title={ __( 'Link Settings', 'snow-monkey-blocks' ) }>
-						<TextControl
-							label={ __( 'Link URL', 'snow-monkey-blocks' ) }
-							value={ linkURL }
-							onChange={ ( value ) => setAttributes( { linkURL: value } ) }
-						/>
+						<BaseControl label={ __( 'Link URL', 'snow-monkey-blocks' ) }>
+							<URLInput
+								value={ linkURL }
+								onChange={ ( value ) => setAttributes( { linkURL: value } ) }
+							/>
+						</BaseControl>
 
 						<SelectControl
 							label={ __( 'Link Target', 'snow-monkey-blocks' ) }


### PR DESCRIPTION
URLInputに変更してみました。

横幅がはみ出す、フォーカス外でもURL予測候補が閉じないに関しては、コア側の問題のため、直す事をせず放置しました。

URLInputの、onChangeを
={ ( value, title ) => とすると、URLが記事URLに該当する場合、記事タイトルを取れます。
（上手く使えば、記事へのリンクか解りやすくする事も出来そうですが、今回は使ってません）