### PR TITLE
カテゴリー一覧の各種修正

### DIFF
--- a/block/categories-list/block.js
+++ b/block/categories-list/block.js
@@ -2,20 +2,157 @@
 
 import toNumber from '../../src/js/helper/to-number';
 
+const { remove, union, indexOf, compact } = lodash;
+const { apiFetch } = wp;
+const { registerStore, withSelect } = wp.data;
 const { registerBlockType } = wp.blocks;
 const { InspectorControls } = wp.editor;
-const { PanelBody, RangeControl, Dashicon } = wp.components;
+const { PanelBody, RangeControl, Spinner, CheckboxControl } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
+const actions = {
+	setArticleCategories( articleCategories ) {
+		return {
+			type: 'SET_ARTICLE_CATEGORIES',
+			articleCategories,
+		};
+	},
+	receiveArticleCategories( path ) {
+		return {
+			type: 'RECEIVE_ARTICLE_CATEGORIES',
+			path,
+		};
+	},
+};
+
+registerStore( 'snow-monkey-blocks/categories-list', {
+	reducer( state = { articleCategories: {} }, action ) {
+		switch ( action.type ) {
+			case 'SET_ARTICLE_CATEGORIES':
+				return {
+					...state,
+					articleCategories: action.articleCategories,
+				};
+			case 'RECEIVE_ARTICLE_CATEGORIES':
+				return action.articleCategories;
+		}
+		return state;
+	},
+	actions,
+	selectors: {
+		receiveArticleCategories( state ) {
+			const { articleCategories } = state;
+			return articleCategories;
+		},
+	},
+	controls: {
+		RECEIVE_ARTICLE_CATEGORIES( action ) {
+			return apiFetch( { path: action.path } );
+		},
+	},
+	resolvers: {
+		* receiveArticleCategories() {
+			const articleCategories = yield actions.receiveArticleCategories( '/wp/v2/categories/?per_page=100' );
+			return actions.setArticleCategories( articleCategories );
+		},
+	},
+} );
+
 registerBlockType( 'snow-monkey-blocks/categories-list', {
 	title: __( 'Categories list', 'snow-monkey-blocks' ),
-	description: __( 'This block is displayed only on the actual screen.', 'snow-monkey-blocks' ),
+	description: __( 'This is a block that displays a list of categories', 'snow-monkey-blocks' ),
 	icon: 'excerpt-view',
 	category: 'smb',
 
-	edit( { attributes, setAttributes } ) {
-		const { articles } = attributes;
+	edit: withSelect( ( select ) => {
+		return {
+			articleCategories: select( 'snow-monkey-blocks/categories-list' ).receiveArticleCategories(),
+		};
+	} )( ( props ) => {
+		const { attributes: { articles, exclusionCategories }, articleCategories, className, setAttributes } = props;
+		if ( ! articleCategories.length ) {
+			return (
+				<p className={ className }>
+					<Spinner />
+					{ __( 'Loading Setting Data', 'snow-monkey-blocks' ) }
+				</p>
+			);
+		}
+
+		const _generateNewExclusionCategories = ( isChecked, categoryId ) => {
+			let newExclusionCategories = [];
+			if ( exclusionCategories !== undefined && exclusionCategories !== null ) {
+				newExclusionCategories = exclusionCategories.split( ',' );
+			}
+			if ( isChecked ) {
+				newExclusionCategories.push( categoryId );
+			} else {
+				newExclusionCategories = remove( newExclusionCategories, ( value ) => categoryId !== value );
+			}
+			return compact( union( newExclusionCategories ) ).join( ',' );
+		};
+
+		const viewCategoriesPanel = () => {
+			const articleCategoriesList = [];
+			articleCategories.map( ( category ) => {
+				articleCategoriesList.push(
+					<CheckboxControl
+						label={ category.name }
+						value={ String( category.id ) }
+						checked={ -1 !== indexOf( exclusionCategories.split( ',' ), String( category.id ) ) }
+						onChange={ ( isChecked ) => {
+							setAttributes( { exclusionCategories: _generateNewExclusionCategories( isChecked, String( category.id ) ) } );
+						} }
+					/>
+				);
+			} );
+			return (
+				<PanelBody title={ __( 'Exclusion Categories Settings', 'snow-monkey-blocks' ) }>
+					<p>{ __( 'Categories with a post count of 0 are not displayed even if they are not excluded', 'snow-monkey-blocks' ) }</p>
+					{ articleCategoriesList }
+				</PanelBody>
+			);
+		};
+
+		const viewCategoriesList = () => {
+			const articleCategoriesList = [];
+			articleCategories.map( ( category ) => {
+				if ( category.count > 0 && ( -1 === indexOf( exclusionCategories.split( ',' ), String( category.id ) ) ) ) {
+					articleCategoriesList.push(
+						<li className="smb-categories-list__item">
+							<div className="smb-categories-list__item__count">
+								{ category.count }
+								<span>{ __( 'articles', 'snow-monkey-blocks' ) }</span>
+							</div>
+							<div className="smb-categories-list__item__detail">
+								<div className="smb-categories-list__item__category-name">
+									{ category.name }
+								</div>
+								{ category.description &&
+									<div className="smb-categories-list__item__category-description">
+										{ category.description }
+									</div>
+								}
+								<div className="smb-categories-list__item__recent-label">
+									{ __( 'Recent posts', 'snow-monkey-blocks' ) }
+								</div>
+								<ul className="smb-categories-list__item__list">
+									<li>{ __( 'Only the actual contribution screen is displayed', 'snow-monkey-blocks' ) }</li>
+								</ul>
+							</div>
+						</li>
+					);
+				}
+			} );
+			return (
+				<div className="smb-categories-list">
+					<ul className="smb-categories-list__list">
+						{ articleCategoriesList }
+					</ul>
+				</div>
+			);
+		};
 
 		return (
 			<Fragment>
@@ -29,20 +166,12 @@ registerBlockType( 'snow-monkey-blocks/categories-list', {
 							max="5"
 						/>
 					</PanelBody>
+					{ viewCategoriesPanel() }
 				</InspectorControls>
-
-				<div className="components-placeholder">
-					<div className="components-placeholder__label">
-						<Dashicon icon="excerpt-view" />
-						{ __( 'Categories list', 'snow-monkey-blocks' ) }
-					</div>
-					<div className="components-placeholder__instructions">
-						{ __( 'displayed categories list on the actual screen.', 'snow-monkey-blocks' ) }
-					</div>
-				</div>
+				{ viewCategoriesList() }
 			</Fragment>
 		);
-	},
+	} ),
 
 	save() {
 		return null;

--- a/block/categories-list/block.php
+++ b/block/categories-list/block.php
@@ -18,6 +18,10 @@ add_action(
 						'type'    => 'number',
 						'default' => '5',
 					],
+					'exclusionCategories' => [
+						'type'    => 'string',
+						'default' => '',
+					],
 				],
 				'render_callback' => function( $attributes, $content ) {
 					return DynamicBlocks::render( 'categories-list', $attributes, $content );

--- a/block/categories-list/view.php
+++ b/block/categories-list/view.php
@@ -10,12 +10,21 @@ $categories = get_categories(
 		'pad_counts' => true,
 	]
 );
+
+$exclusionId = [];
+if ( isset( $attributes['exclusionCategories'] ) && ! empty( $attributes['exclusionCategories'] ) ) {
+	$exclusionId = explode( ',', $attributes['exclusionCategories'] );
+}
 ?>
 <div class="smb-categories-list">
 	<ul class="smb-categories-list__list">
 		<?php foreach ( $categories as $category ) : ?>
-			<?php $category_detail = get_category( $category ); ?>
-
+			<?php
+				$category_detail = get_category( $category );
+				if ( in_array( $category_detail->term_id, $exclusionId ) ) {
+					continue;
+				}
+			?>
 			<li class="smb-categories-list__item">
 				<div class="smb-categories-list__item__count">
 					<?php echo esc_html( $category_detail->count ); ?>
@@ -41,21 +50,19 @@ $categories = get_categories(
 						</div>
 						<ul class="smb-categories-list__item__list">
 							<?php
-							$_wp_query = new \WP_Query(
-								[
-									'cat'                 => $category_detail->term_id,
-									'posts_per_page'      => (string) $attributes['articles'],
-									'order'               => 'ASC',
-									'ignore_sticky_posts' => true,
-									'no_found_rows'       => true,
-									'suppress_filters'    => true,
-								]
-							);
+							$_wp_query = new \WP_Query( [
+								'cat' => $category_detail->term_id,
+								'posts_per_page' => (string) $attributes['articles'],
+								'order' => 'DESC',
+								'ignore_sticky_posts' => true,
+								'no_found_rows' => true,
+								'suppress_filters' => true,
+							] );
 							?>
 							<?php if ( $_wp_query->have_posts() ) : ?>
 								<?php while ( $_wp_query->have_posts() ) : ?>
 									<?php $_wp_query->the_post(); ?>
-									<li><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></li>
+									<li><a href="<?php the_permalink(); ?>"><?php echo ( get_the_title() === '' ? esc_html_e( '(no title)') : get_the_title() ); ?></a></li>
 								<?php endwhile; ?>
 								<?php wp_reset_postdata(); ?>
 							<?php endif; ?>

--- a/languages/snow-monkey-blocks-ja.po
+++ b/languages/snow-monkey-blocks-ja.po
@@ -279,9 +279,27 @@ msgstr "注釈を書く…"
 msgid "Categories list"
 msgstr "カテゴリー一覧"
 
-#: block/categories-list/block.js:13
-msgid "This block is displayed only on the actual screen."
-msgstr "このブロックは実際の画面でのみ表示されます。"
+#: block/categories-list/block.js:64
+msgid "This is a block that displays a list of categories"
+msgstr "このブロックはカテゴリーの一覧を表示します"
+
+#: block/categories-list/block.js:78
+msgid "Loading Setting Data"
+msgstr "設定をロード中"
+
+#: block/categories-list/block.js:111
+msgid "Exclusion Categories Settings"
+msgstr "除外カテゴリーの設定"
+
+#: block/categories-list/block.js:112
+msgid ""
+"Categories with a post count of 0 are not displayed even if they are not "
+"excluded"
+msgstr "投稿数が0のカテゴリは、除外されていない場合でも表示されません"
+
+#: block/categories-list/block.js:141
+msgid "Only the actual contribution screen is displayed"
+msgstr "通常の投稿画面のみ表示されます"
 
 #: block/categories-list/block.js:23
 msgid "Categories list Settings"
@@ -291,9 +309,6 @@ msgstr "カテゴリー一覧設定"
 msgid "Categories List Articles"
 msgstr "カテゴリーリストの記事数"
 
-#: block/categories-list/block.js:40
-msgid "displayed categories list on the actual screen."
-msgstr "カテゴリー一覧は実際の画面でのみ表示されます。"
 
 #: block/child-pages/block.js:8 block/child-pages/block.js:17
 msgid "Child pages"


### PR DESCRIPTION
＜機能追加＞
・除外カテゴリー機能
標準のREST APIとチェックボックスで実装しました。容量問題は解決（？）かと。
・編集画面でのプレビュー
masonry-layoutの問題でやや表示に問題あるようです。今後も再調整していきます。

＜バグ対応＞
・最近の投稿が最近でない記事で表示されている問題の対応
DESCがASCになってしまっていましたので、修正
・タイトルが無い投稿の場合、リンクが正常に出ない問題の対応
タイトルが無い場合は、WPの仕様に合わせて(タイトルなし)でリンク表示に修正
