### PR TITLE
最近の投稿ブロックにカテゴリ選択の追加

### DIFF
--- a/block/categories-list/block.js
+++ b/block/categories-list/block.js
@@ -72,7 +72,8 @@ registerBlockType( 'snow-monkey-blocks/categories-list', {
 			articleCategories: select( 'snow-monkey-blocks/categories-list' ).receiveArticleCategories(),
 		};
 	} )( ( props ) => {
-		const { attributes: { articles, exclusionCategories, orderby, order }, articleCategories, className, setAttributes } = props;
+		const { attributes, articleCategories, className, setAttributes } = props;
+		const { articles, exclusionCategories, orderby, order } = attributes;
 
 		const classes = classnames( 'smb-categories-list', className );
 

--- a/block/recent-posts/block.js
+++ b/block/recent-posts/block.js
@@ -2,19 +2,109 @@
 
 import toNumber from '../../src/js/helper/to-number';
 
+const { apiFetch } = wp;
+const { registerStore, withSelect } = wp.data;
 const { registerBlockType } = wp.blocks;
 const { InspectorControls } = wp.editor;
-const { PanelBody, SelectControl, RangeControl, ServerSideRender, ToggleControl } = wp.components;
+const { PanelBody, SelectControl, RangeControl, ServerSideRender, ToggleControl, Spinner } = wp.components;
 const { Fragment } = wp.element;
 const { __ } = wp.i18n;
 
+const actions = {
+	setPostCategories( postCategories ) {
+		return {
+			type: 'SET_POST_CATEGORIES',
+			postCategories,
+		};
+	},
+	receivePostCategories( path ) {
+		return {
+			type: 'RECEIVE_POST_CATEGORIES',
+			path,
+		};
+	},
+};
+
+registerStore( 'snow-monkey-blocks/recent-posts', {
+	reducer( state = { postCategories: {} }, action ) {
+		switch ( action.type ) {
+			case 'SET_POST_CATEGORIES':
+				return {
+					...state,
+					postCategories: action.postCategories,
+				};
+			case 'RECEIVE_POST_CATEGORIES':
+				return action.postCategories;
+		}
+		return state;
+	},
+	actions,
+	selectors: {
+		receivePostCategories( state ) {
+			const { postCategories } = state;
+			return postCategories;
+		},
+	},
+	controls: {
+		RECEIVE_POST_CATEGORIES( action ) {
+			return apiFetch( { path: action.path } );
+		},
+	},
+	resolvers: {
+		* receivePostCategories() {
+			const postCategories = yield actions.receivePostCategories( '/wp/v2/categories/?per_page=100' );
+			return actions.setPostCategories( postCategories );
+		},
+	},
+} );
+
 registerBlockType( 'snow-monkey-blocks/recent-posts', {
 	title: __( 'Recent posts', 'snow-monkey-blocks' ),
+	description: __( 'This is a block that displays a list of recent posts', 'snow-monkey-blocks' ),
 	icon: 'editor-ul',
 	category: 'smb',
 
-	edit( { attributes, setAttributes } ) {
-		const { postsPerPage, layout, ignoreStickyPosts } = attributes;
+	edit: withSelect( ( select ) => {
+		return {
+			postCategories: select( 'snow-monkey-blocks/recent-posts' ).receivePostCategories(),
+		};
+	} )( ( props ) => {
+		const { attributes, postCategories, className, setAttributes } = props;
+		const { postsPerPage, layout, ignoreStickyPosts, postCategory } = attributes;
+
+		if ( ! postCategories.length ) {
+			return (
+				<p className={ className }>
+					<Spinner />
+					{ __( 'Loading Setting Data', 'snow-monkey-blocks' ) }
+				</p>
+			);
+		}
+
+		const viewCategoriesPanel = () => {
+			const postCategoriesList = [];
+			postCategoriesList.push( {
+				label: __( 'All', 'snow-monkey-blocks' ),
+				value: '',
+			} );
+			postCategories.map( ( category ) => {
+				postCategoriesList.push( {
+					label: String( category.name ),
+					value: String( category.id ),
+				} );
+			} );
+			return (
+				<PanelBody title={ __( 'Categories Settings', 'snow-monkey-blocks' ) }>
+					<p>{ __( 'The category with no post is not displayed', 'snow-monkey-blocks' ) }</p>
+					<SelectControl
+						label={ __( 'Categories', 'snow-monkey-blocks' ) }
+						value={ postCategory }
+						onChange={ ( value ) => setAttributes( { postCategory: value } ) }
+						options={ postCategoriesList }
+					/>
+				</PanelBody>
+			);
+		};
 
 		return (
 			<Fragment>
@@ -54,6 +144,7 @@ registerBlockType( 'snow-monkey-blocks/recent-posts', {
 							onChange={ ( value ) => setAttributes( { ignoreStickyPosts: value } ) }
 						/>
 					</PanelBody>
+					{ viewCategoriesPanel() }
 				</InspectorControls>
 
 				<ServerSideRender
@@ -62,7 +153,7 @@ registerBlockType( 'snow-monkey-blocks/recent-posts', {
 				/>
 			</Fragment>
 		);
-	},
+	} ),
 
 	save() {
 		return null;

--- a/block/recent-posts/block.php
+++ b/block/recent-posts/block.php
@@ -31,6 +31,10 @@ add_action(
 						'type'    => 'boolean',
 						'default' => true,
 					],
+					'postCategory' => [
+						'type'    => 'string',
+						'default' => '',
+					],
 					'className' => [
 						'type' => 'string',
 					],

--- a/block/recent-posts/view.php
+++ b/block/recent-posts/view.php
@@ -17,6 +17,7 @@ $instance = [
 	'posts-per-page'      => $attributes['postsPerPage'],
 	'layout'              => $attributes['layout'],
 	'ignore-sticky-posts' => $attributes['ignoreStickyPosts'],
+	'post-category'       => $attributes['postCategory'],
 	'link-text'           => null,
 	'link-url'            => null,
 ];

--- a/languages/snow-monkey-blocks-ja.po
+++ b/languages/snow-monkey-blocks-ja.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Snow Monkey Blocks\n"
 "Report-Msgid-Bugs-To: https://make.wordpress.org/polyglots/\n"
-"POT-Creation-Date: 2019-03-12 09:26+0900\n"
-"PO-Revision-Date: 2019-03-12 09:26+0900\n"
+"POT-Creation-Date: 2019-03-23 11:29+0900\n"
+"PO-Revision-Date: 2019-03-23 11:30+0900\n"
 "Last-Translator: inc2734 <inc@2inc.org>\n"
 "Language-Team: Takashi Kitajima <inc@2inc.org>\n"
 "Language: ja_JP\n"
@@ -729,6 +729,26 @@ msgstr "テキスト"
 #: block/recent-posts/block.js:52
 msgid "Ignore sticky posts"
 msgstr "先頭固定表示を除外する"
+
+#: block/recent-posts/block.js:63
+msgid "This is a block that displays a list of recent posts"
+msgstr "このブロックは最近の投稿の一覧を表示します"
+
+#: block/recent-posts/block.js:87
+msgid "All"
+msgstr "すべて"
+
+#: block/recent-posts/block.js:97
+msgid "Categories Settings"
+msgstr "カテゴリー設定"
+
+#: block/recent-posts/block.js:98
+msgid "The category with no post is not displayed"
+msgstr "投稿のないカテゴリは表示されません"
+
+#: block/recent-posts/block.js:100
+msgid "Categories"
+msgstr "カテゴリー"
 
 #: block/section-with-bgimage/block.js:15
 msgid "Section (with background image)"


### PR DESCRIPTION
View.phpから動かしているウィジェットの方ですが、どうすれば良いのかちょっと解らなかったので、
そちらはお任せになってしまうと思います。（下手に触ると色々影響しそうだったので）

最近の投稿ブロックで、カテゴリ選択＋view.phpへ選択したカテゴリを、
postCategoryと言うattribute変数に代入する所まで実装しているので、良ければお使いください。
現状はウィジェットにpostCategoryが無いので、選んでもそのままになっています。
多分、ウィジェットで、カテゴリを絞り込むようにすれば出来るかなと思います。
（元々絞り込むattribute等の仕様があれば、ブロックをそれに合わせて変更するので、また言ってください）

migrate等は無くて問題なかったようなので、追加していません。
（問題あれば書いてみますので、言ってください）

後、何かJSLintがおかしかったようなので、カテゴリ一覧の方のattributeのconstを他のブロックに合わせた書き方にしました（^^; 何故、警告が出たのやら…