### PR TITLE
Add limited datetime

### DIFF
--- a/App/Setup/DynamicBlocks.php
+++ b/App/Setup/DynamicBlocks.php
@@ -23,7 +23,7 @@ class DynamicBlocks {
 	 * @param array $attributes This variable can be referenced in the template.
 	 * @return string
 	 */
-	public static function render( $slug, $attributes ) {
+	public static function render( $slug, $attributes, $content = null ) {
 		ob_start();
 		include( SNOW_MONKEY_BLOCKS_DIR_PATH . '/block/' . $slug . '/view.php' );
 		return ob_get_clean();

--- a/block/limited-datetime/_editor.scss
+++ b/block/limited-datetime/_editor.scss
@@ -1,0 +1,5 @@
+.smb-limited-datetime {
+  &__placeholder {
+    
+  }
+}

--- a/block/limited-datetime/_schema.js
+++ b/block/limited-datetime/_schema.js
@@ -1,0 +1,20 @@
+'use strict';
+
+export const schema = {
+	isUseStartDate: {
+		type: 'boolean',
+		default: false,
+	},
+	startDate: {
+		type: 'date',
+		default: null,
+	},
+	isUseEndDate: {
+		type: 'boolean',
+		default: false,
+	},
+	endDate: {
+		type: 'date',
+		default: null,
+	},
+};

--- a/block/limited-datetime/block.js
+++ b/block/limited-datetime/block.js
@@ -1,0 +1,100 @@
+'use strict';
+
+import classnames from 'classnames';
+import moment from 'moment';
+import { schema } from './_schema.js';
+
+const { registerBlockType } = wp.blocks;
+const { InspectorControls, InnerBlocks } = wp.editor;
+const { PanelBody, BaseControl, DateTimePicker, CheckboxControl, Placeholder } = wp.components;
+const { Fragment } = wp.element;
+const { __ } = wp.i18n;
+
+registerBlockType( 'snow-monkey-blocks/limited-datetime', {
+	title: __( 'Limited DateTime', 'snow-monkey-blocks' ),
+	description: __( 'Only the set period is displayed', 'snow-monkey-blocks' ),
+	icon: 'calendar-alt',
+	category: 'smb',
+	attributes: schema,
+	supports: {
+		alignWide: false,
+		customClassName: false,
+		className: false,
+	},
+
+	edit( { attributes, setAttributes, className } ) {
+		const { isUseStartDate, startDate, isUseEndDate, endDate } = attributes;
+
+		const classes = classnames( 'smb-limited-datetime', className );
+
+		let formatedStartDate = __( 'Not used', 'snow-monkey-blocks' );
+		if ( isUseStartDate ) {
+			if ( startDate !== null ) {
+				formatedStartDate = moment( startDate ).format( 'YYYY/MM/DD ddd HH:mm' );
+			} else {
+				formatedStartDate = __( 'Not initialized properly', 'snow-monkey-blocks' );
+			}
+		}
+		let formatedEndDate = __( 'Not used', 'snow-monkey-blocks' );
+		if ( isUseEndDate ) {
+			if ( endDate !== null ) {
+				formatedEndDate = moment( endDate ).format( 'YYYY/MM/DD ddd HH:mm' );
+			} else {
+				formatedEndDate = __( 'Not initialized properly', 'snow-monkey-blocks' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<InspectorControls>
+					<PanelBody title={ __( 'Datetime setting', 'snow-monkey-blocks' ) }>
+						<BaseControl label={ __( 'Start datetime', 'snow-monkey-blocks' ) }>
+							<CheckboxControl
+								label={ __( 'Use start datetime', 'snow-monkey-blocks' ) }
+								checked={ isUseStartDate }
+								onChange={ ( value ) => setAttributes( { isUseStartDate: value } ) }
+							/>
+							<DateTimePicker
+								currentDate={ startDate }
+								onChange={ ( value ) => setAttributes( { startDate: value } ) }
+							/>
+						</BaseControl>
+						<BaseControl label={ __( 'End datetime', 'snow-monkey-blocks' ) }>
+							<CheckboxControl
+								label={ __( 'Use end datetime', 'snow-monkey-blocks' ) }
+								checked={ isUseEndDate }
+								onChange={ ( value ) => setAttributes( { isUseEndDate: value } ) }
+							/>
+							<DateTimePicker
+								currentDate={ endDate }
+								onChange={ ( value ) => setAttributes( { endDate: value } ) }
+							/>
+						</BaseControl>
+
+					</PanelBody>
+				</InspectorControls>
+				<div className={ classes }>
+					<Placeholder
+						className="smb-limited-datetime__placeholder"
+						icon="calendar-alt"
+						label={ __( 'Only the set period is displayed', 'snow-monkey-blocks' ) }
+					>
+						<dl>
+							<dt>{ __( 'Start datetime', 'snow-monkey-blocks' ) }</dt>
+							<dd>{ formatedStartDate }</dd>
+							<dt>{ __( 'End datetime', 'snow-monkey-blocks' ) }</dt>
+							<dd>{ formatedEndDate }</dd>
+						</dl>
+					</Placeholder>
+					<InnerBlocks />
+				</div>
+			</Fragment>
+		);
+	},
+
+	save() {
+		return (
+			<InnerBlocks.Content />
+		);
+	},
+} );

--- a/block/limited-datetime/block.php
+++ b/block/limited-datetime/block.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package snow-monkey-blocks
+ * @author inc2734
+ * @license GPL-2.0+
+ */
+
+use Snow_Monkey\Plugin\Blocks\App\Setup\DynamicBlocks;
+
+add_action(
+	'init',
+	function() {
+		register_block_type(
+			'snow-monkey-blocks/limited-datetime',
+			[
+				'attributes' => [
+					'isUseStartDate' => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'startDate' => [
+						'type'    => 'date',
+						'default' => null,
+					],
+					'isUseEndDate' => [
+						'type'    => 'boolean',
+						'default' => false,
+					],
+					'endDate' => [
+						'type'    => 'date',
+						'default' => null,
+					],
+				],
+				'render_callback' => function( $attributes, $content ) {
+					return DynamicBlocks::render( 'limited-datetime', $attributes, $content );
+				},
+			]
+		);
+	}
+);

--- a/block/limited-datetime/view.php
+++ b/block/limited-datetime/view.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package snow-monkey-blocks
+ * @author inc2734
+ * @license GPL-2.0+
+ */
+
+$is_render = false;
+$now_date = date_i18n( 'U' );
+
+$is_use_start_date = ! empty( $attributes['isUseStartDate'] ) ? $attributes['isUseStartDate'] : false;
+$start_date = null;
+if ( $is_use_start_date && ! empty( $attributes['startDate'] ) ) {
+	$correction_start_date = substr_replace( $attributes['startDate'], '00', -2, 3 );
+	$start_date = date_i18n( 'U', strtotime( $correction_start_date ) );
+}
+
+$is_use_end_date = ! empty( $attributes['isUseEndDate'] ) ? $attributes['isUseEndDate'] : false;
+$end_date = null;
+if ( $is_use_end_date && ! empty( $attributes['endDate'] ) ) {
+	$correction_end_date = substr_replace( $attributes['endDate'], '00', -2, 3 );
+	$end_time = date_i18n( 'U', strtotime( $correction_end_date ) );
+}
+
+try {
+	if ( $start_date === null ) {
+		if ( $end_date !== null && $now_date <= $end_date ) {
+			$is_render = true;
+		}
+	} elseif ( $now_date >= $start_date ) {
+		if ( ( $end_date === null ) || $now_date <= $end_date ) {
+			$is_render = true;
+		}
+	}
+} catch ( Exception $e ) {
+	$is_render = false;
+}
+
+if ( $is_render ) {
+	echo $content;
+}

--- a/languages/snow-monkey-blocks-ja.po
+++ b/languages/snow-monkey-blocks-ja.po
@@ -541,6 +541,42 @@ msgstr "ボタンだけでなくブロック全体にリンクを張ります。
 msgid "Items (Standard)"
 msgstr "項目（スタンダード）"
 
+#: block/limited-datetime/block.js:14
+msgid "Limited DateTime"
+msgstr "期間限定の表示"
+
+#: block/limited-datetime/block.js:15 block/limited-datetime/block.js:80
+msgid "Only the set period is displayed"
+msgstr "設定した期間のみ表示されます"
+
+#: block/limited-datetime/block.js:30 block/limited-datetime/block.js:38
+msgid "Not used"
+msgstr "使用されません"
+
+#: block/limited-datetime/block.js:35 block/limited-datetime/block.js:43
+msgid "Not initialized properly"
+msgstr "正しく初期化されていません"
+
+#: block/limited-datetime/block.js:50
+msgid "Datetime setting"
+msgstr "日時の設定"
+
+#: block/limited-datetime/block.js:51 block/limited-datetime/block.js:83
+msgid "Start datetime"
+msgstr "開始日時"
+
+#: block/limited-datetime/block.js:53
+msgid "Use start datetime"
+msgstr "開始日時を使用する"
+
+#: block/limited-datetime/block.js:62 block/limited-datetime/block.js:85
+msgid "End datetime"
+msgstr "終了日時"
+
+#: block/limited-datetime/block.js:64
+msgid "Use end datetime"
+msgstr "終了日時を使用する"
+
 #: block/list/block.js:15
 msgid "Icon list"
 msgstr "アイコンリスト"

--- a/src/css/blocks-editor.scss
+++ b/src/css/blocks-editor.scss
@@ -22,6 +22,7 @@
 @import '../../block/thumbnail-gallery/editor';
 @import '../../block/categories-list/editor';
 @import '../../block/accordion/editor';
+@import '../../block/limited-datetime/editor';
 
 .#{$_prefix}c-row[data-columns] {
   margin: 0;

--- a/src/js/blocks.js
+++ b/src/js/blocks.js
@@ -32,5 +32,6 @@ import '../../block/categories-list/block.js';
 import '../../block/evaluation-star/block.js';
 import '../../block/accordion/block.js';
 import '../../block/accordion/item/block.js';
+import '../../block/limited-datetime/block.js';
 
 import './_highlighter.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
   externals: {
     react: 'React',
     jquery: 'jQuery',
-    Masonry: 'Masonry'
+    Masonry: 'Masonry',
+    moment: 'moment'
   },
   resolve: {
     extensions: ['.js', '.jsx']


### PR DESCRIPTION
期間限定での表示ブロックを追加しておきます。
このブロックでのインナーブロックを全て設定した期間のみ表示される…ってやつです。

記事中の特定部分の表示を期間限定にしたいと言った時とかに使えます。
（キャンペーンサイトや、事前登録とか…）
エイプリルフール時の一時的なネタ記事表示とかにも使えると思ったので、かなり前に作ってたのを移植しました。
よろしければご確認お願いします。

プレースホルダのデザインがちょっとまとまらなかったので、scssは空です。