### PR TITLE
imageのALTをメディアの代替テキストで設定されるように修正 #143

### DIFF
--- a/block/balloon/_schema.js
+++ b/block/balloon/_schema.js
@@ -12,6 +12,13 @@ export const schema = {
 		attribute: 'src',
 		default: 'https://0.gravatar.com/avatar/00000000000000000000000000000000?s=128&d=mp&r=g',
 	},
+	avatarALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: 'img',
+		attribute: 'alt',
+		default: '',
+	},
 	avatarBorderColor: {
 		type: 'string',
 	},

--- a/block/balloon/block.js
+++ b/block/balloon/block.js
@@ -18,12 +18,12 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, className } ) {
-		const { avatarID, avatarURL, avatarBorderColor, balloonName, balloonBody, modifier } = attributes;
+		const { avatarID, avatarALT, avatarURL, avatarBorderColor, balloonName, balloonBody, modifier } = attributes;
 
 		const renderAvatar = ( obj ) => {
 			return (
 				<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-					<img src={ avatarURL } alt="" className={ `wp-image-${ avatarID }` } />
+					<img src={ avatarURL } alt={ avatarALT } className={ `wp-image-${ avatarID }` } />
 				</Button>
 			);
 		};
@@ -84,7 +84,7 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 							<MediaUpload
 								onSelect={ ( media ) => {
 									const newAvatarURL = !! media.sizes.thumbnail ? media.sizes.thumbnail.url : media.url;
-									setAttributes( { avatarURL: newAvatarURL, avatarID: media.id } );
+									setAttributes( { avatarURL: newAvatarURL, avatarID: media.id, avatarALT: media.alt } );
 								} }
 								type="image"
 								value={ avatarID }
@@ -113,7 +113,7 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 	},
 
 	save( { attributes, className } ) {
-		const { avatarID, avatarURL, avatarBorderColor, balloonName, balloonBody, modifier } = attributes;
+		const { avatarID, avatarALT, avatarURL, avatarBorderColor, balloonName, balloonBody, modifier } = attributes;
 
 		const balloonFigureStyles = {
 			borderColor: avatarBorderColor || undefined,
@@ -134,7 +134,7 @@ registerBlockType( 'snow-monkey-blocks/balloon', {
 						className="smb-balloon__figure"
 						style={ balloonFigureStyles }
 					>
-						<img src={ avatarURL } alt="" className={ `wp-image-${ avatarID }` } />
+						<img src={ avatarURL } alt={ avatarALT } className={ `wp-image-${ avatarID }` } />
 					</div>
 					<div className="smb-balloon__name">
 						{ balloonName }

--- a/block/items/item/_schema.js
+++ b/block/items/item/_schema.js
@@ -49,6 +49,13 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-items__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 	isBlockLink: {
 		type: 'boolean',
 		default: false,

--- a/block/items/item/block-link/_schema.js
+++ b/block/items/item/block-link/_schema.js
@@ -46,4 +46,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-items__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/items/item/block-link/block.js
+++ b/block/items/item/block-link/block.js
@@ -19,13 +19,13 @@ registerBlockType( 'snow-monkey-blocks/items--item--block-link', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const classes = classnames( 'c-row__col', className );
@@ -56,7 +56,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--block-link', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -65,7 +65,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--block-link', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -197,7 +197,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--block-link', {
 	},
 
 	save( { attributes, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const classes = classnames( 'c-row__col', className );
 
@@ -219,7 +219,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--block-link', {
 				>
 					{ !! imageID &&
 						<div className="smb-items__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/items/item/block.js
+++ b/block/items/item/block.js
@@ -25,13 +25,13 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, isBlockLink } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT, isBlockLink } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const classes = classnames( 'c-row__col', className );
@@ -62,7 +62,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -71,7 +71,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -215,7 +215,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, isBlockLink } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT, isBlockLink } = attributes;
 
 		const classes = classnames( 'c-row__col', className );
 
@@ -262,7 +262,7 @@ registerBlockType( 'snow-monkey-blocks/items--item', {
 				<Fragment>
 					{ !! imageID &&
 						<div className="smb-items__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/items/item/standard/_schema.js
+++ b/block/items/item/standard/_schema.js
@@ -46,4 +46,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-items__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/items/item/standard/block.js
+++ b/block/items/item/standard/block.js
@@ -19,13 +19,13 @@ registerBlockType( 'snow-monkey-blocks/items--item--standard', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const classes = classnames( 'c-row__col', className );
@@ -56,7 +56,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--standard', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -65,7 +65,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--standard', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -202,7 +202,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--standard', {
 	},
 
 	save( { attributes, className } ) {
-		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { titleTagName, title, lede, summary, btnLabel, url, target, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const classes = classnames( 'c-row__col', className );
 
@@ -219,7 +219,7 @@ registerBlockType( 'snow-monkey-blocks/items--item--standard', {
 				<div className="smb-items__item">
 					{ !! imageID &&
 						<div className="smb-items__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/media-text/_schema.js
+++ b/block/media-text/_schema.js
@@ -16,6 +16,13 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-media-text__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 	imagePosition: {
 		type: 'string',
 		default: 'right',

--- a/block/media-text/block.js
+++ b/block/media-text/block.js
@@ -41,7 +41,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { title, imageID, imageURL, imagePosition, imageColumnSize } = attributes;
+		const { title, imageID, imageURL, imageALT, imagePosition, imageColumnSize } = attributes;
 
 		const { textColumnWidth, imageColumnWidth } = _getColumnsSize( imageColumnSize );
 
@@ -72,7 +72,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -81,7 +81,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -179,7 +179,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 	},
 
 	save( { attributes, className } ) {
-		const { title, imageID, imageURL, imagePosition, imageColumnSize } = attributes;
+		const { title, imageID, imageURL, imageALT, imagePosition, imageColumnSize } = attributes;
 
 		const { textColumnWidth, imageColumnWidth } = _getColumnsSize( imageColumnSize );
 
@@ -214,7 +214,7 @@ registerBlockType( 'snow-monkey-blocks/media-text', {
 					<div className={ imageColumnClasses }>
 						<div className="smb-media-text__figure">
 							{ imageURL &&
-								<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+								<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 							}
 						</div>
 					</div>

--- a/block/panels/item/horizontal/_schema.js
+++ b/block/panels/item/horizontal/_schema.js
@@ -43,4 +43,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-panels__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/panels/item/horizontal/block.js
+++ b/block/panels/item/horizontal/block.js
@@ -20,13 +20,13 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imagePosition, imageID, imageURL } = attributes;
+		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imagePosition, imageID, imageURL, imageALT } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const PanelsItemFigureImg = () => {
@@ -47,7 +47,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -56,7 +56,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -189,14 +189,14 @@ registerBlockType( 'snow-monkey-blocks/panels--item--horizontal', {
 	},
 
 	save( { attributes, className } ) {
-		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imagePosition, imageID, imageURL } = attributes;
+		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imagePosition, imageID, imageURL, imageALT } = attributes;
 
 		const PanelsItemContent = () => {
 			return (
 				<Fragment>
 					{ !! imageID &&
 						<div className="smb-panels__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/panels/item/vertical/_schema.js
+++ b/block/panels/item/vertical/_schema.js
@@ -39,4 +39,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-panels__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/panels/item/vertical/block.js
+++ b/block/panels/item/vertical/block.js
@@ -20,13 +20,13 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imageID, imageURL } = attributes;
+		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imageID, imageURL, imageALT } = attributes;
 
 		const titleTagNames = [ 'div', 'h2', 'h3' ];
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const PanelsItemFigureImg = () => {
@@ -47,7 +47,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -56,7 +56,7 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -164,14 +164,14 @@ registerBlockType( 'snow-monkey-blocks/panels--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imageID, imageURL } = attributes;
+		const { titleTagName, title, summary, linkLabel, linkURL, linkTarget, imageID, imageURL, imageALT } = attributes;
 
 		const PanelsItemContent = () => {
 			return (
 				<Fragment>
 					{ !! imageID &&
 						<div className="smb-panels__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/pricing-table/item/_schema.js
+++ b/block/pricing-table/item/_schema.js
@@ -49,4 +49,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-pricing-table__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/pricing-table/item/block.js
+++ b/block/pricing-table/item/block.js
@@ -19,11 +19,11 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { title, price, lede, list, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { title, price, lede, list, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const PricingTableItemFigureImg = () => {
@@ -44,7 +44,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -53,7 +53,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -191,7 +191,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { title, price, lede, list, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL } = attributes;
+		const { title, price, lede, list, btnLabel, btnURL, btnTarget, btnBackgroundColor, btnTextColor, imageID, imageURL, imageALT } = attributes;
 
 		const classes = classnames( 'c-row__col', className );
 
@@ -208,7 +208,7 @@ registerBlockType( 'snow-monkey-blocks/pricing-table--item', {
 				<div className="smb-pricing-table__item">
 					{ !! imageID &&
 						<div className="smb-pricing-table__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/section-with-bgimage/_schema.js
+++ b/block/section-with-bgimage/_schema.js
@@ -16,6 +16,13 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-section-with-bgimage__bgimage > img',
+		attribute: 'alt',
+		default: '',
+	},
 	height: {
 		type: 'string',
 		default: 'fit',

--- a/block/section-with-bgimage/block.js
+++ b/block/section-with-bgimage/block.js
@@ -154,7 +154,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 					<div className="smb-section-with-bgimage__mask" style={ maskStyles }></div>
 					<div className={ bgimageClasses } style={ bgimageStyles }>
 						{ imageURL &&
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						}
 					</div>
 					<div className="c-container">

--- a/block/section-with-bgimage/block.js
+++ b/block/section-with-bgimage/block.js
@@ -23,7 +23,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 	},
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { title, imageID, imageURL, height, contentsAlignment, maskColor, maskOpacity, textColor, parallax } = attributes;
+		const { title, imageID, imageURL, imageALT, height, contentsAlignment, maskColor, maskOpacity, textColor, parallax } = attributes;
 
 		const classes = classnames(
 			{
@@ -136,7 +136,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 						labels={ { title: __( 'Image' ) } }
 						onSelect={ ( media ) => {
 							const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-							setAttributes( { imageURL: newImageURL, imageID: media.id } );
+							setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 						} }
 						accept="image/*"
 						allowedTypes={ [ 'image' ] }
@@ -147,7 +147,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -179,7 +179,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 	},
 
 	save( { attributes, className } ) {
-		const { title, imageID, imageURL, height, contentsAlignment, maskColor, maskOpacity, textColor, parallax } = attributes;
+		const { title, imageID, imageURL, imageALT, height, contentsAlignment, maskColor, maskOpacity, textColor, parallax } = attributes;
 
 		const classes = classnames(
 			{
@@ -215,7 +215,7 @@ registerBlockType( 'snow-monkey-blocks/section-with-bgimage', {
 			<div className={ classes } style={ sectionStyles }>
 				<div className="smb-section-with-bgimage__mask" style={ maskStyles }></div>
 				<div className={ bgimageClasses } style={ bgimageStyles }>
-					<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+					<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 				</div>
 				<div className="c-container">
 					{ ! RichText.isEmpty( title ) &&

--- a/block/slider/item/_schema.js
+++ b/block/slider/item/_schema.js
@@ -12,6 +12,13 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-slider__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 	caption: {
 		source: 'html',
 		selector: '.smb-slider__item__caption',

--- a/block/slider/item/block.js
+++ b/block/slider/item/block.js
@@ -18,11 +18,11 @@ registerBlockType( 'snow-monkey-blocks/slider--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { imageID, imageURL, caption } = attributes;
+		const { imageID, imageURL, imageALT, caption } = attributes;
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const SliderItemFigureImg = () => {
@@ -43,7 +43,7 @@ registerBlockType( 'snow-monkey-blocks/slider--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -52,7 +52,7 @@ registerBlockType( 'snow-monkey-blocks/slider--item', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -81,14 +81,14 @@ registerBlockType( 'snow-monkey-blocks/slider--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { imageID, imageURL, caption } = attributes;
+		const { imageID, imageURL, imageALT, caption } = attributes;
 
 		const classes = classnames( 'smb-slider__item', className );
 
 		return (
 			<div className={ classes }>
 				<div className="smb-slider__item__figure">
-					<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+					<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 				</div>
 
 				{ ! RichText.isEmpty( caption ) &&

--- a/block/step/item/_schema.js
+++ b/block/step/item/_schema.js
@@ -23,6 +23,13 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-step__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 	linkLabel: {
 		source: 'html',
 		selector: '.smb-step__item__link__label',

--- a/block/step/item/block.js
+++ b/block/step/item/block.js
@@ -19,11 +19,11 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { title, numberColor, imagePosition, imageID, imageURL, linkLabel, linkURL, linkTarget, linkColor } = attributes;
+		const { title, numberColor, imagePosition, imageID, imageURL, imageALT, linkLabel, linkURL, linkTarget, linkColor } = attributes;
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const StepItemFigureImg = () => {
@@ -44,7 +44,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -53,7 +53,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 						<button
 							className="smb-remove-button"
 							onClick={ () => {
-								setAttributes( { imageURL: '', imageID: 0 } );
+								setAttributes( { imageURL: '', imageALT: '', imageID: 0 } );
 							} }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
@@ -198,7 +198,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { title, numberColor, imagePosition, imageID, imageURL, linkLabel, linkURL, linkTarget, linkColor } = attributes;
+		const { title, numberColor, imagePosition, imageID, imageURL, imageALT, linkLabel, linkURL, linkTarget, linkColor } = attributes;
 
 		const classes = classnames(
 			'smb-step__item',
@@ -226,7 +226,7 @@ registerBlockType( 'snow-monkey-blocks/step--item', {
 				<div className="smb-step__item__body">
 					{ !! imageID &&
 						<div className="smb-step__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					}
 

--- a/block/testimonial/item/_schema.js
+++ b/block/testimonial/item/_schema.js
@@ -12,6 +12,13 @@ export const schema = {
 		attribute: 'src',
 		default: 'https://0.gravatar.com/avatar/00000000000000000000000000000000?s=128&d=mp&r=g',
 	},
+	avatarALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-testimonial__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 	name: {
 		source: 'html',
 		selector: '.smb-testimonial__item__name',

--- a/block/testimonial/item/block.js
+++ b/block/testimonial/item/block.js
@@ -18,12 +18,12 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { avatarID, avatarURL, name, lede, content } = attributes;
+		const { avatarID, avatarURL, avatarALT, name, lede, content } = attributes;
 
 		const renderAvatar = ( obj ) => {
 			return (
 				<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-					<img src={ avatarURL } alt="" className={ `wp-image-${ avatarID }` } />
+					<img src={ avatarURL } alt={ avatarALT } className={ `wp-image-${ avatarID }` } />
 				</Button>
 			);
 		};
@@ -38,8 +38,7 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 							<MediaUpload
 								onSelect={ ( media ) => {
 									const newAvatarURL = !! media.sizes.thumbnail ? media.sizes.thumbnail.url : media.url;
-									setAttributes( { avatarURL: newAvatarURL } );
-									setAttributes( { avatarID: media.id } );
+									setAttributes( { avatarURL: newAvatarURL, avatarID: media.id, avatarALT: media.alt } );
 								} }
 								type="image"
 								value={ avatarID }
@@ -79,7 +78,7 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { avatarID, avatarURL, name, lede, content } = attributes;
+		const { avatarID, avatarURL, avatarALT, name, lede, content } = attributes;
 
 		const colClasses = classnames( 'c-row__col', className );
 
@@ -87,7 +86,7 @@ registerBlockType( 'snow-monkey-blocks/testimonial--item', {
 			<div className={ colClasses }>
 				<div className="smb-testimonial__item">
 					<div className="smb-testimonial__item__figure">
-						<img src={ avatarURL } alt="" className={ `wp-image-${ avatarID }` } />
+						<img src={ avatarURL } alt={ avatarALT } className={ `wp-image-${ avatarID }` } />
 					</div>
 					<div className="smb-testimonial__item__body">
 						<div className="smb-testimonial__item__content">

--- a/block/thumbnail-gallery/item/_schema.js
+++ b/block/thumbnail-gallery/item/_schema.js
@@ -12,4 +12,11 @@ export const schema = {
 		attribute: 'src',
 		default: '',
 	},
+	imageALT: {
+		type: 'string',
+		source: 'attribute',
+		selector: '.smb-thumbnail-gallery__item__figure > img',
+		attribute: 'alt',
+		default: '',
+	},
 };

--- a/block/thumbnail-gallery/item/block.js
+++ b/block/thumbnail-gallery/item/block.js
@@ -18,11 +18,11 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, isSelected, className } ) {
-		const { imageID, imageURL } = attributes;
+		const { imageID, imageURL, imageALT } = attributes;
 
 		const onSelectImage = ( media ) => {
 			const newImageURL = !! media.sizes && !! media.sizes.large ? media.sizes.large.url : media.url;
-			setAttributes( { imageURL: newImageURL, imageID: media.id } );
+			setAttributes( { imageURL: newImageURL, imageID: media.id, imageALT: media.alt } );
 		};
 
 		const ItemFigureImg = () => {
@@ -43,7 +43,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery--item', {
 						render={ ( obj ) => {
 							return (
 								<Button className="image-button" onClick={ obj.open } style={ { padding: 0 } }>
-									<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+									<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 								</Button>
 							);
 						} }
@@ -51,7 +51,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery--item', {
 					{ isSelected &&
 						<button
 							className="smb-remove-button"
-							onClick={ () => setAttributes( { imageURL: '', imageID: 0 } ) }
+							onClick={ () => setAttributes( { imageURL: '', imageALT: '', imageID: 0 } ) }
 						>{ __( 'Remove', 'snow-monkey-blocks' ) }</button>
 					}
 				</Fragment>
@@ -74,7 +74,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { imageID, imageURL } = attributes;
+		const { imageID, imageURL, imageALT } = attributes;
 
 		const classes = classnames( 'smb-thumbnail-gallery__item', className );
 
@@ -83,7 +83,7 @@ registerBlockType( 'snow-monkey-blocks/thumbnail-gallery--item', {
 				{ !! imageID &&
 					<div className={ classes }>
 						<div className="smb-thumbnail-gallery__item__figure">
-							<img src={ imageURL } alt="" className={ `wp-image-${ imageID }` } />
+							<img src={ imageURL } alt={ imageALT } className={ `wp-image-${ imageID }` } />
 						</div>
 					</div>
 				}


### PR DESCRIPTION
imageがあるブロック全て修正掛けたので予想以上に修正箇所が多くなってしまいました。
申し訳ないっすー。

メディアの代替テキストで設定されるようにしています。
（トピックの返信時にはタイトルとかでやれば良いやと思ってましたが、メディア内を良く見たら代替テキスト設定があったので…それを使いました）

変更箇所が多いので、インスペクターの項目に追加して入力させる等の追加修正は、後方修正的にもキツいので今後って事で…。（メディアの説明で変更するって事で、ブロック内で入力させるのは要らない気もしましたし）

動作確認の方、一通り手動でも確認してはいますが、箇所が多いので漏れがあるかもしれません。
すみませんが、二重チェックの意味でそちらでもソースチェックの方をお願いします。