### PR TITLE
faqブロックのQとAの文字の変更対応 #136

### DIFF
--- a/block/faq/item/_schema.js
+++ b/block/faq/item/_schema.js
@@ -15,4 +15,14 @@ export const schema = {
 	answerColor: {
 		type: 'string',
 	},
+	questionLabel: {
+		source: 'html',
+		selector: '.smb-faq__item__question__label',
+		default: 'Q',
+	},
+	answerLabel: {
+		source: 'html',
+		selector: '.smb-faq__item__answer__label',
+		default: 'A',
+	},
 };

--- a/block/faq/item/block.js
+++ b/block/faq/item/block.js
@@ -6,8 +6,9 @@ import { deprecated } from './_deprecated.js';
 
 const { registerBlockType } = wp.blocks;
 const { RichText, InspectorControls, PanelColorSettings } = wp.editor;
+const { PanelBody, BaseControl, TextControl } = wp.components;
 const { Fragment } = wp.element;
-const { __ } = wp.i18n;
+const { __, sprintf } = wp.i18n;
 
 registerBlockType( 'snow-monkey-blocks/faq--item', {
 	title: __( 'Item', 'snow-monkey-blocks' ),
@@ -18,7 +19,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 	attributes: schema,
 
 	edit( { attributes, setAttributes, className } ) {
-		const { question, answer, questionColor, answerColor } = attributes;
+		const { question, answer, questionColor, answerColor, questionLabel, answerLabel } = attributes;
 
 		const classes = classnames( 'smb-faq__item', className );
 
@@ -33,6 +34,24 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 		return (
 			<Fragment>
 				<InspectorControls>
+					<PanelBody title={ __( 'Label Settings', 'snow-monkey-blocks' ) }>
+						<BaseControl label={ __( 'Question Label', 'snow-monkey-blocks' ) }>
+							<TextControl
+								value={ questionLabel }
+								placeholder={ __( 'Q', 'snow-monkey-blocks' ) }
+								onChange={ ( value ) => setAttributes( { questionLabel: value } ) }
+								help={ sprintf( __( 'Recommend length up to %d', 'snow-monkey-blocks' ), Number( 2 ) ) }
+							/>
+						</BaseControl>
+						<BaseControl label={ __( 'Answer Label', 'snow-monkey-blocks' ) }>
+							<TextControl
+								value={ answerLabel }
+								placeholder={ __( 'A', 'snow-monkey-blocks' ) }
+								onChange={ ( value ) => setAttributes( { answerLabel: value } ) }
+								help={ sprintf( __( 'Recommend length up to %d', 'snow-monkey-blocks' ), Number( 2 ) ) }
+							/>
+						</BaseControl>
+					</PanelBody>
 					<PanelColorSettings
 						title={ __( 'Color Settings', 'snow-monkey-blocks' ) }
 						colorSettings={ [
@@ -54,7 +73,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 				<div className={ classes }>
 					<div className="smb-faq__item__question">
 						<div className="smb-faq__item__question__label" style={ faqItemQestionLabelStyles }>
-							Q
+							{ questionLabel }
 						</div>
 						<RichText
 							className="smb-faq__item__question__body"
@@ -68,7 +87,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 
 					<div className="smb-faq__item__answer">
 						<div className="smb-faq__item__answer__label" style={ faqItemAnswerLabelStyles }>
-							A
+							{ answerLabel }
 						</div>
 						<RichText
 							className="smb-faq__item__answer__body"
@@ -84,7 +103,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 	},
 
 	save( { attributes, className } ) {
-		const { question, answer, questionColor, answerColor } = attributes;
+		const { question, answer, questionColor, answerColor, questionLabel, answerLabel } = attributes;
 
 		const classes = classnames( 'smb-faq__item', className );
 
@@ -100,7 +119,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 			<div className={ classes }>
 				<div className="smb-faq__item__question">
 					<div className="smb-faq__item__question__label" style={ faqItemQestionLabelStyles }>
-						Q
+						{ questionLabel }
 					</div>
 					<div className="smb-faq__item__question__body">
 						<RichText.Content value={ question } />
@@ -109,7 +128,7 @@ registerBlockType( 'snow-monkey-blocks/faq--item', {
 
 				<div className="smb-faq__item__answer">
 					<div className="smb-faq__item__answer__label" style={ faqItemAnswerLabelStyles }>
-						A
+						{ answerLabel }
 					</div>
 					<div className="smb-faq__item__answer__body">
 						<RichText.Content value={ answer } />

--- a/languages/snow-monkey-blocks-ja.po
+++ b/languages/snow-monkey-blocks-ja.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Snow Monkey Blocks\n"
 "Report-Msgid-Bugs-To: https://make.wordpress.org/polyglots/\n"
-"POT-Creation-Date: 2019-04-13 09:53+0900\n"
-"PO-Revision-Date: 2019-04-13 09:53+0900\n"
+"POT-Creation-Date: 2019-04-21 15:08+0900\n"
+"PO-Revision-Date: 2019-04-21 15:10+0900\n"
 "Last-Translator: inc2734 <inc@2inc.org>\n"
 "Language-Team: Takashi Kitajima <inc@2inc.org>\n"
 "Language: ja_JP\n"
@@ -530,7 +530,32 @@ msgstr "FAQを列挙できます。"
 msgid "It is a child block of the FAQ block."
 msgstr "FAQブロックの子ブロックです。"
 
-#: block/faq/item/block.js:42
+#: block/faq/item/block.js:37
+msgid "Label Settings"
+msgstr "ラベル設定"
+
+#: block/faq/item/block.js:38
+msgid "Question Label"
+msgstr "質問のラベル"
+
+#: block/faq/item/block.js:41
+msgid "Q"
+msgstr "Q"
+
+#: block/faq/item/block.js:43 block/faq/item/block.js:51
+#, javascript-format
+msgid "Recommend length up to %d"
+msgstr "文字長は%dまでを推奨します"
+
+#: block/faq/item/block.js:46
+msgid "Answer Label"
+msgstr "回答のラベル"
+
+#: block/faq/item/block.js:49
+msgid "A"
+msgstr "A"
+
+#: block/faq/item/block.js:61
 msgid "Question Color"
 msgstr "質問の色"
 


### PR DESCRIPTION
制限を掛けるかは悩む所ですが、一応の仮という感じで修正しました。
TextControlにmaxlengthを設定すれば多分文字数は制限できる…かと。
２文字までが推奨文字長かなと思ったので、helpに書いてます。適当に長さは変えていただければ。

対応してから思ったんですが、親のブロックにラベル設定項目を付けて、子はそれを読ませる方が統一性出そうな気もしますね…（一つ一つの項目に設定は自由度がある分、ちょっと面倒な気も）

一応のプルリクって事で。マージ判断は任せます(^^;