### PR TITLE
枠を開いている際にタイトル領域と１番目のアイテムの間で開閉できてしまうのを修正

### DIFF
--- a/block/accordion/_block.scss
+++ b/block/accordion/_block.scss
@@ -43,8 +43,7 @@
       position: relative;
       z-index: 2;
       display: none;
-      @include _margin-top(1);
-      @include _padding(0, .5);
+      @include _padding(1, .5, 0);
       @include _content();
     }
   }


### PR DESCRIPTION
accordionブロックの、枠を開いている際に、タイトル領域と１番目のアイテムの間の隙間の部分で開閉できてしまっているようなので、
margin-topをpadding-topにする形で調整しました。
