### PR TITLE
期間限定表示ブロック 終了日時が反映されない不具合を修正

### DIFF
--- a/block/limited-datetime/view.php
+++ b/block/limited-datetime/view.php
@@ -19,7 +19,7 @@ $is_use_end_date = ! empty( $attributes['isUseEndDate'] ) ? $attributes['isUseEn
 $end_date = null;
 if ( $is_use_end_date && ! empty( $attributes['endDate'] ) ) {
 	$correction_end_date = substr_replace( $attributes['endDate'], '00', -2, 3 );
-	$end_time = date_i18n( 'U', strtotime( $correction_end_date ) );
+	$end_date = date_i18n( 'U', strtotime( $correction_end_date ) );
 }
 
 try {


### PR DESCRIPTION
終了日時が反映されなかったため修正しました。
ご確認いただければ幸いです。