### PR TITLE
_enqueue_block_scripts should return value

### DIFF
--- a/App/Setup/Assets.php
+++ b/App/Setup/Assets.php
@@ -31,7 +31,7 @@ class Assets {
 	 */
 	public function _enqueue_block_scripts( $block_content, $block ) {
 		if ( is_admin() ) {
-			return;
+			return $block_content;
 		}
 
 		// Parallax assets for the section with background image/video block


### PR DESCRIPTION
For reference, please see the issue described in #375 

The early return in `_enqueue_block_scripts` should return the original value, as it runs on a  filter hook.