### PR TITLE
Fix the label of "Wrapper Tag" controller

### DIFF
--- a/block/section-with-bgimage/edit.js
+++ b/block/section-with-bgimage/edit.js
@@ -395,7 +395,7 @@ export default function ( {
 					title={ __( 'Block Settings', 'snow-monkey-blocks' ) }
 				>
 					<BaseControl
-						label={ __( 'Title Tag', 'snow-monkey-blocks' ) }
+						label={ __( 'Wrapper Tag', 'snow-monkey-blocks' ) }
 						id="snow-monkey-blocks/section-with-bgimage/wrapper-tag-name"
 					>
 						<div className="smb-list-icon-selector">


### PR DESCRIPTION
「セクション（背景画像・動画）」のコントローラーにラベルのミスを見つけましたので、プルリクエストおおくりします。