### PR TITLE
キーボード操作時、アコーディオンブロックにフォーカスが当たった場合にアウトラインを表示させる。

### DIFF
--- a/block/accordion/style.scss
+++ b/block/accordion/style.scss
@@ -52,6 +52,10 @@
       width: 100% !important;
       opacity: 0 !important;
       outline: none !important;
+      &:focus-visible {
+        opacity: 1!important;
+        outline: 1px solid !important;
+      }
     }
 
     &__body {


### PR DESCRIPTION
アクセシビリティのテストをしていて気が付いたのですが、キーボード操作時、アコーディオンブロックにフォーカスが当たってもアウトラインが表示されません。
アコーディオンはチェックボックスなので、フォーカスが当たった状態で`スペース`キーを使用して開閉が可能です。