### PR TITLE
情報ブロックにラベル文字色設定機能の追加

### DIFF
--- a/src/blocks/information/block.json
+++ b/src/blocks/information/block.json
@@ -38,6 +38,9 @@
 		},
 		"borderWidth": {
 			"type": "string"
+		},
+		"labelColumnTextColor": {
+			"type": "string"
 		}
 	},
 	"providesContext": {

--- a/src/blocks/information/block.json
+++ b/src/blocks/information/block.json
@@ -30,6 +30,9 @@
 		"labelColumnBackgroundColor": {
 			"type": "string"
 		},
+		"labelColumnTextColor": {
+			"type": "string"
+		},
 		"contentColumnBackgroundColor": {
 			"type": "string"
 		},
@@ -37,9 +40,6 @@
 			"type": "string"
 		},
 		"borderWidth": {
-			"type": "string"
-		},
-		"labelColumnTextColor": {
 			"type": "string"
 		}
 	},

--- a/src/blocks/information/edit.js
+++ b/src/blocks/information/edit.js
@@ -61,6 +61,7 @@ export default function ( { attributes, setAttributes, className, clientId } ) {
 		contentColumnBackgroundColor,
 		borderColor,
 		borderWidth,
+		labelColumnTextColor,
 	} = attributes;
 
 	const classes = classnames( 'smb-information', className, {
@@ -77,6 +78,8 @@ export default function ( { attributes, setAttributes, className, clientId } ) {
 			contentColumnBackgroundColor || undefined,
 		'--smb-information--border-color': borderColor || undefined,
 		'--smb-information--border-width': borderWidth || undefined,
+		'--smb-information--label-column-text-color':
+			labelColumnTextColor || undefined,
 	};
 
 	const blockProps = useBlockProps( {
@@ -112,6 +115,17 @@ export default function ( { attributes, setAttributes, className, clientId } ) {
 								} ),
 							label: __(
 								'Label column background color',
+								'snow-monkey-blocks'
+							),
+						},
+						{
+							colorValue: labelColumnTextColor,
+							onColorChange: ( value ) =>
+								setAttributes( {
+									labelColumnTextColor: value,
+								} ),
+							label: __(
+								'Label column text color',
 								'snow-monkey-blocks'
 							),
 						},

--- a/src/blocks/information/edit.js
+++ b/src/blocks/information/edit.js
@@ -58,10 +58,10 @@ export default function ( { attributes, setAttributes, className, clientId } ) {
 		smIsSplitColumn,
 		columnPadding,
 		labelColumnBackgroundColor,
+		labelColumnTextColor,
 		contentColumnBackgroundColor,
 		borderColor,
 		borderWidth,
-		labelColumnTextColor,
 	} = attributes;
 
 	const classes = classnames( 'smb-information', className, {
@@ -74,12 +74,12 @@ export default function ( { attributes, setAttributes, className, clientId } ) {
 			: undefined,
 		'--smb-information--label-column-background-color':
 			labelColumnBackgroundColor || undefined,
+		'--smb-information--label-column-text-color':
+			labelColumnTextColor || undefined,
 		'--smb-information--content-column-background-color':
 			contentColumnBackgroundColor || undefined,
 		'--smb-information--border-color': borderColor || undefined,
 		'--smb-information--border-width': borderWidth || undefined,
-		'--smb-information--label-column-text-color':
-			labelColumnTextColor || undefined,
 	};
 
 	const blockProps = useBlockProps( {

--- a/src/blocks/information/save.js
+++ b/src/blocks/information/save.js
@@ -12,6 +12,7 @@ export default function ( { attributes, className } ) {
 		contentColumnBackgroundColor,
 		borderColor,
 		borderWidth,
+		labelColumnTextColor,
 	} = attributes;
 
 	const classes = classnames( 'smb-information', className, {
@@ -28,6 +29,8 @@ export default function ( { attributes, className } ) {
 			contentColumnBackgroundColor || undefined,
 		'--smb-information--border-color': borderColor || undefined,
 		'--smb-information--border-width': borderWidth || undefined,
+		'--smb-information--label-column-text-color':
+			labelColumnTextColor || undefined,
 	};
 
 	return (

--- a/src/blocks/information/save.js
+++ b/src/blocks/information/save.js
@@ -9,10 +9,10 @@ export default function ( { attributes, className } ) {
 		smIsSplitColumn,
 		columnPadding,
 		labelColumnBackgroundColor,
+		labelColumnTextColor,
 		contentColumnBackgroundColor,
 		borderColor,
 		borderWidth,
-		labelColumnTextColor,
 	} = attributes;
 
 	const classes = classnames( 'smb-information', className, {
@@ -25,12 +25,12 @@ export default function ( { attributes, className } ) {
 			: undefined,
 		'--smb-information--label-column-background-color':
 			labelColumnBackgroundColor || undefined,
+		'--smb-information--label-column-text-color':
+			labelColumnTextColor || undefined,
 		'--smb-information--content-column-background-color':
 			contentColumnBackgroundColor || undefined,
 		'--smb-information--border-color': borderColor || undefined,
 		'--smb-information--border-width': borderWidth || undefined,
-		'--smb-information--label-column-text-color':
-			labelColumnTextColor || undefined,
 	};
 
 	return (

--- a/src/blocks/information/style.scss
+++ b/src/blocks/information/style.scss
@@ -10,13 +10,13 @@
 	--smb-information--gap: var(--_margin1);
 	--smb-information--style--border--border-color: var(--_lighter-color-gray);
 	--smb-information--label-column-background-color: transparent;
+	--smb-information--label-column-text-color: var(--_color-text);
 	--smb-information--content-column-background-color: transparent;
 	--smb-information--column-padding: 0px;
 	--smb-information--label-align: left;
 	--smb-information--label-vertical-align: start;
 	--smb-information--border-color: transparent;
 	--smb-information--border-width: 0px;
-	--smb-information--label-column-text-color: var(--_color-text);
 
 	&__body {
 		> * + * {

--- a/src/blocks/information/style.scss
+++ b/src/blocks/information/style.scss
@@ -16,6 +16,7 @@
 	--smb-information--label-vertical-align: start;
 	--smb-information--border-color: transparent;
 	--smb-information--border-width: 0px;
+	--smb-information--label-column-text-color: var(--_color-text);
 
 	&__body {
 		> * + * {
@@ -53,6 +54,7 @@
 		text-align: var(--smb-information--label-align);
 		background-color: var(--smb-information--label-column-background-color);
 		border-left: var(--smb-information--border-width) solid var(--smb-information--border-color);
+		color: var(--smb-information--label-column-text-color);
 	}
 
 	.smb-information__item__body {


### PR DESCRIPTION
お疲れ様です。
情報ブロックのラベルの文字色を設定できるように修正してみました。
よろしくお願いします

- masterにPR出してしまったのですが、違うブランチのほうがよければ出し直します 
- 翻訳ファイルがこちらだと作れないので、すみません翻訳は手をつけてません