### PR TITLE
クラシックメタボックスを Gutenberg プラグインパネルに移行してリビジョン UI を改善

### DIFF
--- a/snow-monkey-blocks.php
+++ b/snow-monkey-blocks.php
@@ -170,7 +170,6 @@ class Bootstrap {
 		include_once __DIR__ . '/dist/blocks/thumbnail-gallery/index.php';
 		include_once __DIR__ . '/dist/blocks/thumbnail-gallery/item/index.php';
 	}
-
 }
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/snow-monkey-blocks.php
+++ b/snow-monkey-blocks.php
@@ -41,7 +41,6 @@ class Bootstrap {
 
 		add_filter( 'block_categories_all', array( $this, '_block_categories_all' ) );
 		add_action( 'init', array( $this, '_register_blocks' ) );
-		add_action( 'add_meta_boxes', array( $this, '_add_pr_meta_box' ) );
 	}
 
 	/**
@@ -172,51 +171,6 @@ class Bootstrap {
 		include_once __DIR__ . '/dist/blocks/thumbnail-gallery/item/index.php';
 	}
 
-	/**
-	 * Add meta box for the Snow Monkey PR when the Gutenberg page or not using the Snow Monkey.
-	 *
-	 * @param string $post_type The post type.
-	 * @return void
-	 */
-	public function _add_pr_meta_box( $post_type ) {
-		if ( ! is_block_editor() || is_pro() ) {
-			return;
-		}
-
-		add_meta_box(
-			'snow-monkey-pr',
-			__( '[ PR ] Premium WordPress Theme Snow Monkey', 'snow-monkey-blocks' ),
-			array( $this, '_pr_meta_box_html' ),
-			$post_type,
-			'normal'
-		);
-	}
-
-	/**
-	 * Display Snow Monkey PR meta box html.
-	 *
-	 * @return void
-	 */
-	public function _pr_meta_box_html() {
-		?>
-		<p>
-			<?php
-			printf(
-				// translators: %1$s: Start a tag, %2$s: End a tag.
-				esc_html__( 'Snow Monkey Blocks is optimized for the %1$sSnow Monkey%2$s theme, but it can also be used with other themes.', 'snow-monkey-blocks' ),
-				'<a href="https://snow-monkey.2inc.org/" target="_blank">',
-				'</a>'
-			);
-			printf(
-				// translators: %1$s: Start a tag, %2$s: End a tag.
-				esc_html__( 'When used together with the %1$sSnow Monkey%2$s theme, it can be displayed with the most beautiful balance, and it is displayed on the edit screen with the same design as the front screen.', 'snow-monkey-blocks' ),
-				'<a href="https://snow-monkey.2inc.org/" target="_blank">',
-				'</a>'
-			);
-			?>
-		</p>
-		<?php
-	}
 }
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -74,3 +74,5 @@ addFilter(
 	'smb/editor/with-inspector-controls',
 	withInspectorControls
 );
+
+import './editor/pr-panel';

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -12,6 +12,7 @@ import {
 	editGridColumnProp,
 	editGridRowProp,
 } from './editor/dimensions/dimensions';
+import './editor/pr-panel';
 
 function addEditProps( settings ) {
 	settings = editFlexGrowProp( settings );
@@ -74,5 +75,3 @@ addFilter(
 	'smb/editor/with-inspector-controls',
 	withInspectorControls
 );
-
-import './editor/pr-panel';

--- a/src/js/editor/pr-panel.js
+++ b/src/js/editor/pr-panel.js
@@ -3,17 +3,17 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
-if (!window.smb?.isPro) {
+if ( ! window.smb?.isPro ) {
 	const SnowMonkeyPrPanel = () => (
 		<PluginDocumentSettingPanel
 			name="snow-monkey-pr"
-			title={__(
+			title={ __(
 				'[ PR ] Premium WordPress Theme Snow Monkey',
 				'snow-monkey-blocks'
-			)}
+			) }
 		>
 			<p>
-				{createInterpolateElement(
+				{ createInterpolateElement(
 					__(
 						'Snow Monkey Blocks is optimized for the <a>Snow Monkey</a> theme, but it can also be used with other themes.',
 						'snow-monkey-blocks'
@@ -28,10 +28,10 @@ if (!window.smb?.isPro) {
 							/>
 						),
 					}
-				)}
+				) }
 			</p>
 			<p>
-				{createInterpolateElement(
+				{ createInterpolateElement(
 					__(
 						'When used together with the <a>Snow Monkey</a> theme, it can be displayed with the most beautiful balance, and it is displayed on the edit screen with the same design as the front screen.',
 						'snow-monkey-blocks'
@@ -46,10 +46,10 @@ if (!window.smb?.isPro) {
 							/>
 						),
 					}
-				)}
+				) }
 			</p>
 		</PluginDocumentSettingPanel>
 	);
 
-	registerPlugin('snow-monkey-pr', { render: SnowMonkeyPrPanel });
+	registerPlugin( 'snow-monkey-pr', { render: SnowMonkeyPrPanel } );
 }

--- a/src/js/editor/pr-panel.js
+++ b/src/js/editor/pr-panel.js
@@ -3,17 +3,17 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 
-if ( ! window.smb?.isPro ) {
+if (!window.smb?.isPro) {
 	const SnowMonkeyPrPanel = () => (
 		<PluginDocumentSettingPanel
 			name="snow-monkey-pr"
-			title={ __(
+			title={__(
 				'[ PR ] Premium WordPress Theme Snow Monkey',
 				'snow-monkey-blocks'
-			) }
+			)}
 		>
 			<p>
-				{ createInterpolateElement(
+				{createInterpolateElement(
 					__(
 						'Snow Monkey Blocks is optimized for the <a>Snow Monkey</a> theme, but it can also be used with other themes.',
 						'snow-monkey-blocks'
@@ -24,14 +24,14 @@ if ( ! window.smb?.isPro ) {
 							<a
 								href="https://snow-monkey.2inc.org/"
 								target="_blank"
-								rel="noreferrer"
+								rel="noopener noreferrer"
 							/>
 						),
 					}
-				) }
+				)}
 			</p>
 			<p>
-				{ createInterpolateElement(
+				{createInterpolateElement(
 					__(
 						'When used together with the <a>Snow Monkey</a> theme, it can be displayed with the most beautiful balance, and it is displayed on the edit screen with the same design as the front screen.',
 						'snow-monkey-blocks'
@@ -42,14 +42,14 @@ if ( ! window.smb?.isPro ) {
 							<a
 								href="https://snow-monkey.2inc.org/"
 								target="_blank"
-								rel="noreferrer"
+								rel="noopener noreferrer"
 							/>
 						),
 					}
-				) }
+				)}
 			</p>
 		</PluginDocumentSettingPanel>
 	);
 
-	registerPlugin( 'snow-monkey-pr', { render: SnowMonkeyPrPanel } );
+	registerPlugin('snow-monkey-pr', { render: SnowMonkeyPrPanel });
 }

--- a/src/js/editor/pr-panel.js
+++ b/src/js/editor/pr-panel.js
@@ -1,0 +1,53 @@
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+if ( ! window.smb?.isPro ) {
+	const SnowMonkeyPrPanel = () => (
+		<PluginDocumentSettingPanel
+			name="snow-monkey-pr"
+			title={ __(
+				'[ PR ] Premium WordPress Theme Snow Monkey',
+				'snow-monkey-blocks'
+			) }
+		>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'Snow Monkey Blocks is optimized for the <a>Snow Monkey</a> theme, but it can also be used with other themes.',
+						'snow-monkey-blocks'
+					),
+					{
+						a: (
+							<a
+								href="https://snow-monkey.2inc.org/"
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					}
+				) }
+			</p>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'When used together with the <a>Snow Monkey</a> theme, it can be displayed with the most beautiful balance, and it is displayed on the edit screen with the same design as the front screen.',
+						'snow-monkey-blocks'
+					),
+					{
+						a: (
+							<a
+								href="https://snow-monkey.2inc.org/"
+								target="_blank"
+								rel="noreferrer"
+							/>
+						),
+					}
+				) }
+			</p>
+		</PluginDocumentSettingPanel>
+	);
+
+	registerPlugin( 'snow-monkey-pr', { render: SnowMonkeyPrPanel } );
+}

--- a/src/js/editor/pr-panel.js
+++ b/src/js/editor/pr-panel.js
@@ -20,6 +20,7 @@ if ( ! window.smb?.isPro ) {
 					),
 					{
 						a: (
+							// eslint-disable-next-line jsx-a11y/anchor-has-content
 							<a
 								href="https://snow-monkey.2inc.org/"
 								target="_blank"
@@ -37,6 +38,7 @@ if ( ! window.smb?.isPro ) {
 					),
 					{
 						a: (
+							// eslint-disable-next-line jsx-a11y/anchor-has-content
 							<a
 								href="https://snow-monkey.2inc.org/"
 								target="_blank"


### PR DESCRIPTION
## 概要

issue #881 対応。クラシックメタボックス（`snow-monkey-pr`）を `PluginDocumentSettingPanel` に置き換え、Gutenberg ネイティブのリビジョン UI を復元する。

---

## 変更内容

| ファイル | 内容 |
|---|---|
| `snow-monkey-blocks.php` | `add_meta_boxes` フック・`_add_pr_meta_box()`・`_pr_meta_box_html()` を削除 |
| `src/js/editor/pr-panel.js` | 新規作成（`PluginDocumentSettingPanel` による PR パネル登録） |
| `src/js/editor.js` | `import './editor/pr-panel';` を追加 |

---

## 検証結果

- `npm run build` 成功（webpack compiled with 3 warnings）
- wp-env（WordPress 6.8）でブロックエディターを開き、サイドバーに「[ PR ] Premium WordPress Theme Snow Monkey」パネルが表示されることを確認
- リビジョン UI が Gutenberg ネイティブに戻っていることを確認

---

Closes #881